### PR TITLE
Add some ResultTree tests

### DIFF
--- a/src/ast/test/include/test/test_ast.h
+++ b/src/ast/test/include/test/test_ast.h
@@ -5,6 +5,7 @@
 #include "util/strutil.h"
 
 #include <gtest/gtest.h>
+#include <utility>
 
 namespace sq::test {
 

--- a/src/parser/Sq.g4
+++ b/src/parser/Sq.g4
@@ -21,7 +21,7 @@ list_slice_step: INTEGER;
 
 BOOLEAN_TRUE: 'true';
 BOOLEAN_FALSE: 'false';
-ID: [a-zA-Z_]+;
+ID: [a-zA-Z_][a-zA-Z0-9]*;
 WS: [ \t\r\n]+ -> skip;
 DQ_STR: '"' (~'"' | '\\"' )* '"';
 INTEGER: '-'?[0-9]+;


### PR DESCRIPTION
For #4: Add unit tests for existing code

Add tests that ResultTree passes parameters into the system correctly.

Fix a bug found where parameter names containing digits were being
rejected by the parser.