### PR TITLE
Add more ResultTree tests and fix issues found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,4 +50,14 @@ endif()
 
 add_compile_options(${SQ_WARNING_FLAGS})
 
+option(FORCE_COLOR "Force coloured compiler output" TRUE)
+if("${FORCE_COLOR}" OR "$ENV{CLICOLOR_FORCE}")
+    string(APPEND CMAKE_CXX_CLANG_TIDY ";--use-color")
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL GNU)
+        add_compile_options(-fdiagnostics-color=always)
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL Clang)
+        add_compile_options(-fcolor-diagnostics)
+    endif()
+endif()
+
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(sq main.cpp)
 target_link_libraries(sq gsl)
 
 add_executable(sq-test test.cpp)
+set_target_properties(sq-test PROPERTIES CXX_CLANG_TIDY "")
 target_link_libraries(sq-test gtest_main)
 
 foreach(SQ_LIB ${SQ_ALL_LIBS})

--- a/src/results/src/Filter.cpp
+++ b/src/results/src/Filter.cpp
@@ -74,7 +74,7 @@ constexpr auto slurp_range_into_vector = SlurpRangeIntoVector{};
 template <typename R>
 Int get_range_size(R& rng)
 {
-    if constexpr (!ranges::forward_range<R>)
+    if constexpr (!ranges::forward_range<R> && !ranges::sized_range<R>)
     {
         throw SqException{"get_range_size: internal error: bad range category"};
         return 0;
@@ -226,7 +226,8 @@ struct FilterImpl<ast::SliceSpec>
         }
         if (start_.value_or(0) < 0 || stop_.value_or(0) < 0)
         {
-            if (HasRangeCategory{ranges::category::forward}(result))
+            if (HasRangeCategory{ranges::category::forward}(result) ||
+                HasRangeCategory{ranges::category::sized}(result))
             {
                 return std::move(result);
             }
@@ -322,7 +323,7 @@ private:
     template <typename R, typename = util::disable_lvalues_t<R>>
     static auto mixed_index_pos_step(R&& rng, Int start, Int stop, Int step)
     {
-        assert(ranges::forward_range<R>);
+        assert(ranges::forward_range<R> || ranges::sized_range<R>);
         assert(step > 0);
         assert(start < 0 || stop < 0);
         auto size = get_range_size(rng);
@@ -337,7 +338,7 @@ private:
     template <typename R, typename = util::disable_lvalues_t<R>>
     static auto neg_index_no_stop_pos_step(R&& rng, Int start, Int step)
     {
-        assert(ranges::forward_range<R>);
+        assert(ranges::forward_range<R> || ranges::sized_range<R>);
         assert(step > 0);
         assert(start < 0);
         start += get_range_size(rng);

--- a/src/results/test/include/test/results_test_util.h
+++ b/src/results/test/include/test/results_test_util.h
@@ -162,6 +162,46 @@ static ResultTree obj_data_tree(Args&&... args)
     return ResultTree{std::move(obj_data)};
 }
 
+static constexpr auto input = ranges::category::input;
+static constexpr auto forward = ranges::category::forward;
+static constexpr auto bidirectional = ranges::category::bidirectional;
+static constexpr auto random_access = ranges::category::random_access;
+static constexpr auto sized = ranges::category::sized;
+
 } // namespace sq::test
+
+namespace ranges  {
+
+std::ostream& operator<<(std::ostream& os, const category& cat)
+{
+    if ((cat & category::sized) == category::sized)
+    {
+        os << "sized ";
+    }
+    if ((cat & category::mask) == category::random_access) 
+    {
+        os << "random_access";
+    }
+    else if((cat & category::mask) == category::bidirectional)
+    {
+        os << "bidirectional";
+    }
+    else if ((cat & category::mask) == category::forward)
+    {
+        os << "forward";
+    }
+    else if ((cat & category::mask) == category::input)
+    {
+        os << "input";
+    }
+    else
+    {
+        os << "unknown";
+    }
+    return os;
+}
+
+} // namespace ranges
+
 
 #endif // SQ_INCLUDE_GUARD_results_test_results_test_util_h_

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -3,10 +3,12 @@ set(SQ_UTIL_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
 add_library(sq_util
     "${SQ_UTIL_INCLUDE_DIR}/util/MoveOnlyTree.h"
-    "${SQ_UTIL_INCLUDE_DIR}/util/strutil.h"
-    "${SQ_UTIL_INCLUDE_DIR}/util/typeutil.h"
     "${SQ_UTIL_SRC_DIR}/MoveOnlyTree.cpp"
+
+    "${SQ_UTIL_INCLUDE_DIR}/util/strutil.h"
     "${SQ_UTIL_SRC_DIR}/strutil.cpp"
+
+    "${SQ_UTIL_INCLUDE_DIR}/util/typeutil.h"
     "${SQ_UTIL_SRC_DIR}/typeutil.cpp"
 )
 target_include_directories(sq_util PUBLIC "${SQ_UTIL_INCLUDE_DIR}")

--- a/src/util/test/include/test/test_util.h
+++ b/src/util/test/include/test/test_util.h
@@ -4,7 +4,9 @@
 #include <gtest/gtest.h>
 #include <initializer_list>
 
-namespace sq::util::test {
+namespace sq::test {
+
+using namespace sq::util;
 
 TEST(UtilTest, JoinCStrings)
 {
@@ -134,7 +136,6 @@ TEST(UtilTest, MoveOnlyTree)
     EXPECT_EQ(tree.data(), 0);
     EXPECT_EQ(tree.children(), mkchildren(no_children));
 
-
     tree.children().emplace_back(1);
     tree.children().emplace_back(2);
     tree.children().emplace_back(3);
@@ -148,4 +149,4 @@ TEST(UtilTest, MoveOnlyTree)
     EXPECT_TRUE(tree.children()[2].children().empty());
 }
 
-} // namespace sq::util::test
+} // namespace sq::test


### PR DESCRIPTION
For #4: Add unit tests for existing code

Add tests that ResultTree makes minimal system calls when element access
or slice filters are being used.

Fix two issues found in Filter.cpp by these tests.

Add a CMake option to force color output from the compiler and/or static
analyzer even when the output is not going to a terminal.