### PR TITLE
Fix issues found by CodeChecker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 add_subdirectory(3rdparty)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 project(Sq
     VERSION 0.0.1
@@ -52,7 +53,6 @@ add_compile_options(${SQ_WARNING_FLAGS})
 
 option(FORCE_COLOR "Force coloured compiler output" TRUE)
 if("${FORCE_COLOR}" OR "$ENV{CLICOLOR_FORCE}")
-    string(APPEND CMAKE_CXX_CLANG_TIDY ";--use-color")
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL GNU)
         add_compile_options(-fdiagnostics-color=always)
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL Clang)

--- a/src/ast/include/ast/ast.h
+++ b/src/ast/include/ast/ast.h
@@ -21,9 +21,8 @@ public:
     AstData& operator=(AstData&&) = default;
     ~AstData() noexcept = default;
 
-    template <typename String>
-    explicit AstData(String&& name)
-        : name_(std::forward<String>(name))
+    explicit AstData(std::string_view name)
+        : name_(name)
     { }
 
     const std::string& name() const { return name_; }

--- a/src/common_types/include/common_types/Field.h
+++ b/src/common_types/include/common_types/Field.h
@@ -35,13 +35,15 @@ using Result = std::variant<
 class Field
 {
 public:
-    virtual ~Field() noexcept = default;
-
     virtual Result get(std::string_view member, const FieldCallParams& params) const = 0;
     virtual Primitive to_primitive() const = 0;
 
-protected:
-    Field() = default;
+    Field(const Field&) = delete;
+    Field(Field&&) = delete;
+    Field& operator=(const Field&) = delete;
+    Field& operator=(Field&&) = delete;
+    Field() noexcept = default;
+    virtual ~Field() noexcept = default;
 };
 
 } // namespace sq

--- a/src/common_types/include/common_types/Primitive.h
+++ b/src/common_types/include/common_types/Primitive.h
@@ -20,7 +20,7 @@ using Primitive = std::variant<
 >;
 
 template <typename T>
-static const char* const primitive_type_name_v = nullptr;
+inline constexpr const char* primitive_type_name_v = nullptr;
 
 template <typename T>
 static const char* primitive_type_name(const T& value);

--- a/src/common_types/include/common_types/Primitive.inl.h
+++ b/src/common_types/include/common_types/Primitive.inl.h
@@ -6,16 +6,16 @@
 namespace sq {
 
 template <>
-const char* const primitive_type_name_v<PrimitiveString> = "PrimitiveString";
+inline constexpr const char* primitive_type_name_v<PrimitiveString> = "PrimitiveString";
 
 template <>
-const char* const primitive_type_name_v<PrimitiveInt> = "PrimitiveInt";
+inline constexpr const char* primitive_type_name_v<PrimitiveInt> = "PrimitiveInt";
 
 template <>
-const char* const primitive_type_name_v<PrimitiveFloat> = "PrimitiveFloat";
+inline constexpr const char* primitive_type_name_v<PrimitiveFloat> = "PrimitiveFloat";
 
 template <>
-const char* const primitive_type_name_v<PrimitiveBool> = "PrimitiveBool";
+inline constexpr const char* primitive_type_name_v<PrimitiveBool> = "PrimitiveBool";
 
 namespace detail {
 

--- a/src/results/test/include/test/results_test_util.h
+++ b/src/results/test/include/test/results_test_util.h
@@ -75,10 +75,11 @@ struct FakeField
     FakeField(Result&& result);
     FakeField(ResultGenerator result_generator);
     FakeField();
-    FakeField(const FakeField&) = default;
-    FakeField(FakeField&&) = default;
-    FakeField& operator=(const FakeField&) = default;
-    FakeField& operator=(FakeField&&) = default;
+    FakeField(const FakeField&) = delete;
+    FakeField(FakeField&&) = delete;
+    FakeField& operator=(const FakeField&) = delete;
+    FakeField& operator=(FakeField&&) = delete;
+    ~FakeField() noexcept = default;
 
     Result get(
         const std::string_view member,

--- a/src/serialization/test/include/test/test_serialization.h
+++ b/src/serialization/test/include/test/test_serialization.h
@@ -9,14 +9,12 @@
 
 namespace sq::test {
 
-using namespace serialization;
-
-static bool isspace(char c)
+inline bool isspace(char c)
 {
     return std::isspace(static_cast<unsigned char>(c));
 }
 
-void test_serialization(const std::string_view expected, ResultTree&& tree)
+inline void test_serialization(const std::string_view expected, ResultTree&& tree)
 {
     SCOPED_TRACE(testing::Message()
         << "test_serialization("
@@ -24,7 +22,7 @@ void test_serialization(const std::string_view expected, ResultTree&& tree)
         << "tree)"
     );
     auto ss = std::ostringstream{};
-    serialize_results(ss, tree);
+    serialization::serialize_results(ss, tree);
 
     auto serialized = ss.str();
     serialized |= ranges::actions::remove_if(isspace);

--- a/src/util/include/util/MoveOnlyTree.h
+++ b/src/util/include/util/MoveOnlyTree.h
@@ -18,8 +18,8 @@ public:
     MoveOnlyTree(const MoveOnlyTree&) = delete;
     MoveOnlyTree& operator=(const MoveOnlyTree&) = delete;
 
-    MoveOnlyTree(MoveOnlyTree&&) = default;
-    MoveOnlyTree& operator=(MoveOnlyTree&&) = default;
+    MoveOnlyTree(MoveOnlyTree&&) noexcept = default;
+    MoveOnlyTree& operator=(MoveOnlyTree&&) noexcept = default;
     ~MoveOnlyTree() noexcept = default;
 
     template <typename... Args>


### PR DESCRIPTION
src/ast/include/ast/ast.h:
* constructor accepting a forwarding reference can hide the move
  constructor

src/common_types/include/common_types/Field.h:
* class 'Field' defines a default destructor but does not define a copy
  constructor, a copy assignment operator, a move constructor or a move
  assignment operator

src/results/test/include/test/results_test_util.h:
* class 'FakeField' defines a copy constructor, a copy assignment
  operator, a move constructor and a move assignment operator but does
  not define a destructor

src/common_types/include/common_types/Primitive.h:
src/common_types/include/common_types/Primitive.inl.h:
* variable 'primitive_type_name_v<std::__cxx11::basic_string<char> >'
  defined in a header file; variable definitions in header files can
  lead to ODR violations
* ...and the same issue with the other specializations of
  primitive_type_name_v.

serialization/test/include/test/test_serialization.h:
* function 'test_serialization' defined in a header file; function
  definitions in header files can lead to ODR violations

util/include/util/MoveOnlyTree.h:
* move constructors should be marked noexcept
* move assignment operators should be marked noexcept