### PR TITLE
Fix building with Ninja

### DIFF
--- a/3rdparty/lua.cmake
+++ b/3rdparty/lua.cmake
@@ -15,6 +15,9 @@ endif()
 
 ExternalProject_Add(lua_project
     URL https://www.lua.org/ftp/lua-${SQ_LUA_VER}.tar.gz
+    BUILD_BYPRODUCTS
+        "${SQ_HOST_TOOLS_BIN_DIR}/lua"
+        "${SQ_HOST_TOOLS_BIN_DIR}/luac"
     DOWNLOAD_NO_PROGRESS TRUE
     INSTALL_DIR "${SQ_HOST_TOOLS_PREFIX}"
     CONFIGURE_COMMAND


### PR DESCRIPTION
Ninja complains that it doesn't know how to build the lua executable
unless we explicitly tell it that the lua_project external project
produces it.