### PR TITLE
Turn off irrelevant clang-tidy checks from new version

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,7 +5,9 @@ Checks: >-
     -fuchsia-overloaded-operator,
     -fuchsia-trailing-return,
     -google-runtime-references,
+    -llvmlibc-*,
     -llvm-header-guard,
+    -misc-no-recursion,
     -modernize-use-trailing-return-type,
     -modernize-pass-by-value,
 


### PR DESCRIPTION
Clang-tidy 11 comes with some new llvm-project specific checks that
aren't relevant for us. Turn them off.