### PR TITLE
Add support for filtering results by their primitive values

### DIFF
--- a/src/common_types/include/common_types/Token.h
+++ b/src/common_types/include/common_types/Token.h
@@ -31,22 +31,23 @@ public:
      */
     enum class Kind
     {
-        BoolTrue,
         BoolFalse,
-        LParen,
-        RParen,
-        LBrace,
-        RBrace,
-        LBracket,
-        RBracket,
-        Dot,
-        Equals,
-        Comma,
+        BoolTrue,
         Colon,
-        Identifier,
+        Comma,
+        Dot,
         DQString,
+        Eof,
+        Equals,
+        Float,
+        Identifier,
         Integer,
-        Eof
+        LBrace,
+        LBracket,
+        LParen,
+        RBrace,
+        RBracket,
+        RParen
     };
 
     /**

--- a/src/common_types/src/LexError.cpp
+++ b/src/common_types/src/LexError.cpp
@@ -21,7 +21,7 @@ namespace {
 {
     auto ss = std::stringstream{};
     ss << "lex error: Failed to identify token at position " << pos
-       << "\n" << query
+       << "\n" << query << "\n"
        << std::string(util::to_size(pos), ' ') << "^\n";
 
     return ss.str();

--- a/src/common_types/src/ParseError.cpp
+++ b/src/common_types/src/ParseError.cpp
@@ -22,7 +22,7 @@ namespace {
     auto ss = std::ostringstream{};
     ss << "parse error: unexpected " << token
        << "; Expecting one of: " << util::join(expecting)
-       << token.query()
+       << "\n" << token.query()
        << "\n" << std::string(util::to_size(token.pos()), ' ') << "^\n";
     return ss.str();
 }

--- a/src/common_types/src/Token.cpp
+++ b/src/common_types/src/Token.cpp
@@ -17,22 +17,23 @@ constexpr std::string_view token_kind_to_str(Token::Kind kind)
 {
     switch (kind)
     {
-        case Token::Kind::BoolTrue: return "BoolTrue";
         case Token::Kind::BoolFalse: return "BoolFalse";
-        case Token::Kind::LParen: return "LParen";
-        case Token::Kind::RParen: return "RParen";
-        case Token::Kind::LBrace: return "LBrace";
-        case Token::Kind::RBrace: return "RBrace";
-        case Token::Kind::LBracket: return "LBracket";
-        case Token::Kind::RBracket: return "RBracket";
-        case Token::Kind::Dot: return "Dot";
-        case Token::Kind::Equals: return "Equals";
-        case Token::Kind::Comma: return "Comma";
+        case Token::Kind::BoolTrue: return "BoolTrue";
         case Token::Kind::Colon: return "Colon";
-        case Token::Kind::Identifier: return "Identifier";
+        case Token::Kind::Comma: return "Comma";
+        case Token::Kind::Dot: return "Dot";
         case Token::Kind::DQString: return "DQString";
-        case Token::Kind::Integer: return "Integer";
         case Token::Kind::Eof: return "Eof";
+        case Token::Kind::Equals: return "Equals";
+        case Token::Kind::Float: return "Float";
+        case Token::Kind::Identifier: return "Identifier";
+        case Token::Kind::Integer: return "Integer";
+        case Token::Kind::LBrace: return "LBrace";
+        case Token::Kind::LBracket: return "LBracket";
+        case Token::Kind::LParen: return "LParen";
+        case Token::Kind::RBrace: return "RBrace";
+        case Token::Kind::RBracket: return "RBracket";
+        case Token::Kind::RParen: return "RParen";
     }
     return "UnknownTokenKind";
 }

--- a/src/parser/include/parser/FilterSpec.h
+++ b/src/parser/include/parser/FilterSpec.h
@@ -6,6 +6,8 @@
 #ifndef SQ_INCLUDE_GUARD_parser_FilterSpec_h_
 #define SQ_INCLUDE_GUARD_parser_FilterSpec_h_
 
+#include "common_types/Primitive.h"
+
 #include <gsl/gsl>
 #include <iosfwd>
 #include <optional>
@@ -46,10 +48,30 @@ std::ostream& operator<<(std::ostream& os, SliceSpec lss);
 [[nodiscard]] bool operator==(const SliceSpec& lhs, const SliceSpec& rhs);
 [[nodiscard]] bool operator!=(const SliceSpec& lhs, const SliceSpec& rhs);
 
+enum class ComparisonOperator
+{
+    Equals
+};
+
+/**
+ * Represents a comparison to determine whether to keep a field or not.
+ */
+struct ComparisonSpec
+{
+    ComparisonOperator op_;
+    Primitive value_;
+};
+
+std::ostream& operator<<(std::ostream& os, const ComparisonOperator& op);
+std::ostream& operator<<(std::ostream& os, const ComparisonSpec& cs);
+[[nodiscard]] bool operator==(const ComparisonSpec& lhs, const ComparisonSpec& rhs);
+[[nodiscard]] bool operator!=(const ComparisonSpec& lhs, const ComparisonSpec& rhs);
+
 using FilterSpec = std::variant<
     NoFilterSpec,
     ElementAccessSpec,
-    SliceSpec
+    SliceSpec,
+    ComparisonSpec
 >;
 
 } // namespace sq::parser

--- a/src/parser/include/parser/Parser.h
+++ b/src/parser/include/parser/Parser.h
@@ -47,8 +47,11 @@ private:
     [[nodiscard]] std::optional<Primitive> parse_primitive_value();
     [[nodiscard]] std::optional<PrimitiveString> parse_dqstring();
     [[nodiscard]] std::optional<PrimitiveBool> parse_bool();
+    [[nodiscard]] std::optional<PrimitiveFloat> parse_float();
     [[nodiscard]] bool parse_named_parameter(Ast& parent);
     [[nodiscard]] bool parse_list_filter(Ast& parent);
+    [[nodiscard]] bool parse_slice_or_element_access(Ast& parent);
+    [[nodiscard]] bool parse_condition(Ast& parent);
 
     template <std::integral Int>
     [[nodiscard]] std::optional<Int> parse_integer();

--- a/src/parser/src/FilterSpec.cpp
+++ b/src/parser/src/FilterSpec.cpp
@@ -5,11 +5,28 @@
 
 #include "parser/FilterSpec.h"
 
+#include "common_types/Primitive.h"
+#include "util/ASSERT.h"
 #include "util/strutil.h"
 
 #include <iostream>
 
 namespace sq::parser {
+
+namespace {
+
+const char* comparison_operator_to_str(ComparisonOperator op)
+{
+    switch (op)
+    {
+        case ComparisonOperator::Equals: return "=";
+    }
+    ASSERT(false);
+    return "Unknown ComparisonOperator";
+}
+
+} // namespace
+
 
 std::ostream& operator<<(std::ostream& os, [[maybe_unused]] NoFilterSpec nlfs)
 {
@@ -61,6 +78,30 @@ bool operator==(const SliceSpec& lhs, const SliceSpec& rhs)
 }
 
 bool operator!=(const SliceSpec& lhs, const SliceSpec& rhs)
+{
+    return !(lhs == rhs);
+}
+
+std::ostream& operator<<(std::ostream& os, const ComparisonOperator& op)
+{
+    os << comparison_operator_to_str(op);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const ComparisonSpec& cs)
+{
+    os << cs.op_
+       << primitive_to_str(cs.value_);
+    return os;
+}
+
+bool operator==(const ComparisonSpec& lhs, const ComparisonSpec& rhs)
+{
+    return lhs.op_ == rhs.op_ &&
+           lhs.value_ == rhs.value_;
+}
+
+bool operator!=(const ComparisonSpec& lhs, const ComparisonSpec& rhs)
 {
     return !(lhs == rhs);
 }

--- a/src/parser/test/test_parser.cpp
+++ b/src/parser/test/test_parser.cpp
@@ -12,6 +12,7 @@
 #include "util/strutil.h"
 
 #include <gtest/gtest.h>
+#include <limits>
 #include <string_view>
 #include <utility>
 
@@ -21,7 +22,7 @@ namespace {
 using namespace sq::parser;
 using Size = Ast::Children::size_type;
 
-inline constexpr auto no_filter_spec = FilterSpec{NoFilterSpec{}};
+inline constexpr auto no_filter_spec = NoFilterSpec{};
 
 parser::Ast generate_ast(std::string_view query)
 {
@@ -232,6 +233,41 @@ INSTANTIATE_TEST_SUITE_P(
             SliceSpec{1, 1, 1}
         },
         SimpleTestCase{
+            "a[=true]",
+            FieldCallParams{},
+            ComparisonSpec{ComparisonOperator::Equals, true}
+        },
+        SimpleTestCase{
+            "a[=false]",
+            FieldCallParams{},
+            ComparisonSpec{ComparisonOperator::Equals, false}
+        },
+        SimpleTestCase{
+            "a[=\"str\"]",
+            FieldCallParams{},
+            ComparisonSpec{ComparisonOperator::Equals, to_primitive("str")}
+        },
+        SimpleTestCase{
+            "a[=-10]",
+            FieldCallParams{},
+            ComparisonSpec{ComparisonOperator::Equals, to_primitive(-10)}
+        },
+        SimpleTestCase{
+            "a[=99]",
+            FieldCallParams{},
+            ComparisonSpec{ComparisonOperator::Equals, to_primitive(99)}
+        },
+        SimpleTestCase{
+            "a[=-10.2]",
+            FieldCallParams{},
+            ComparisonSpec{ComparisonOperator::Equals, to_primitive(-10.2)}
+        },
+        SimpleTestCase{
+            "a[=99.2]",
+            FieldCallParams{},
+            ComparisonSpec{ComparisonOperator::Equals, to_primitive(99.2)}
+        },
+        SimpleTestCase{
             "a(1)",
             params(1),
             no_filter_spec
@@ -239,6 +275,66 @@ INSTANTIATE_TEST_SUITE_P(
         SimpleTestCase{
             "a(-1)",
             params(-1),
+            no_filter_spec
+        },
+        SimpleTestCase{
+            "a(9223372036854775807)",
+            params(std::numeric_limits<PrimitiveInt>::max()),
+            no_filter_spec
+        },
+        SimpleTestCase{
+            "a(-9223372036854775808)",
+            params(std::numeric_limits<PrimitiveInt>::min()),
+            no_filter_spec
+        },
+        SimpleTestCase{
+            "a(1.)",
+            params(1.),
+            no_filter_spec
+        },
+        SimpleTestCase{
+            "a(-1.)",
+            params(-1.),
+            no_filter_spec
+        },
+        SimpleTestCase{
+            "a(1.0)",
+            params(1.0),
+            no_filter_spec
+        },
+        SimpleTestCase{
+            "a(-1.0)",
+            params(-1.0),
+            no_filter_spec
+        },
+        SimpleTestCase{
+            "a(0.0)",
+            params(0.0),
+            no_filter_spec
+        },
+        SimpleTestCase{
+            "a(-0.0)",
+            params(-0.0),
+            no_filter_spec
+        },
+        SimpleTestCase{
+            "a(0.)",
+            params(0.),
+            no_filter_spec
+        },
+        SimpleTestCase{
+            "a(-0.)",
+            params(-0.),
+            no_filter_spec
+        },
+        SimpleTestCase{
+            "a(.0)",
+            params(.0),
+            no_filter_spec
+        },
+        SimpleTestCase{
+            "a(-.0)",
+            params(-.0),
             no_filter_spec
         },
         SimpleTestCase{
@@ -295,6 +391,16 @@ INSTANTIATE_TEST_SUITE_P(
             "a(1, true, \"str\", n=9)",
             params(1, true, "str", named("n", 9)),
             no_filter_spec
+        },
+        SimpleTestCase{
+            "a(true_n=1)",
+            params(named("true_n", 1)),
+            no_filter_spec
+        },
+        SimpleTestCase{
+            "a(false_n=1)",
+            params(named("false_n", 1)),
+            no_filter_spec
         }
     )
 );
@@ -336,7 +442,13 @@ INSTANTIATE_TEST_SUITE_P(
         "a(p-x)",
         "a[",
         "a]",
-        "a[]"
+        "a[]",
+        "a[=]",
+        "a[10=]",
+        "a[1.0]",
+        "a[1.0:]",
+        "a[:1.0:]",
+        "a[::1.0]"
     )
 );
 

--- a/src/results/test/include/test/results_test_util.h
+++ b/src/results/test/include/test/results_test_util.h
@@ -10,8 +10,9 @@
 
 namespace sq::test {
 
-using testing::Return;
-using testing::ByMove;
+using ::testing::Return;
+using ::testing::ByMove;
+using ::testing::_;
 
 using sq::results::ResultTree;
 using Data = ResultTree::Data;

--- a/src/system/include/system/standard/SqRootImpl.h
+++ b/src/system/include/system/standard/SqRootImpl.h
@@ -19,6 +19,7 @@ public:
     [[nodiscard]] static Result get_int(PrimitiveInt value);
     [[nodiscard]] static Result get_ints(PrimitiveInt start, const PrimitiveInt* stop);
     [[nodiscard]] static Result get_bool(PrimitiveBool value);
+    [[nodiscard]] static Result get_float(PrimitiveFloat value);
     [[nodiscard]] Primitive to_primitive() const override;
 };
 

--- a/src/system/schema.json
+++ b/src/system/schema.json
@@ -489,6 +489,22 @@
                             "default_value": false
                         }
                     ]
+                },
+                {
+                    "name": "float",
+                    "doc": "Get an SqFloat system object",
+                    "return_type": "SqFloat",
+                    "return_list": false,
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "value",
+                            "doc": "the value of the float to get",
+                            "type": "PrimitiveFloat",
+                            "required": false,
+                            "default_value": 0.0
+                        }
+                    ]
                 }
             ]
         },

--- a/src/system/src/standard/SqRootImpl.cpp
+++ b/src/system/src/standard/SqRootImpl.cpp
@@ -6,6 +6,7 @@
 #include "system/standard/SqRootImpl.h"
 
 #include "system/standard/SqBoolImpl.h"
+#include "system/standard/SqFloatImpl.h"
 #include "system/standard/SqIntImpl.h"
 #include "system/standard/SqPathImpl.h"
 #include "system/standard/SqSchemaImpl.h"
@@ -58,6 +59,11 @@ Result SqRootImpl::get_ints(
 Result SqRootImpl::get_bool(PrimitiveBool value)
 {
     return std::make_unique<SqBoolImpl>(value);
+}
+
+Result SqRootImpl::get_float(PrimitiveFloat value)
+{
+    return std::make_unique<SqFloatImpl>(value);
 }
 
 Primitive SqRootImpl::to_primitive() const


### PR DESCRIPTION
For: #6: Allow filtering by value of field

In order to do that, we'll need a way for the user to specify float
values, so add support for that too.