### PR TITLE
Improve code readability

### DIFF
--- a/src/common_types/include/common_types/Field.h
+++ b/src/common_types/include/common_types/Field.h
@@ -7,6 +7,7 @@
 #define SQ_INCLUDE_GUARD_common_types_Field_h_
 
 #include "common_types/Primitive.h"
+#include "util/typeutil.h"
 
 #include <memory>
 #include <range/v3/view/any_view.hpp>
@@ -54,12 +55,12 @@ public:
      * @param member the name of the field to access.
      * @param params parameters to pass to system when accessing the field.
      */
-    [[nodiscard]] virtual Result get(std::string_view member, const FieldCallParams& params) const = 0;
+    SQ_ND virtual Result get(std::string_view member, const FieldCallParams& params) const = 0;
 
     /**
      * Get a representation of the system object as a Primitive type.
      */
-    [[nodiscard]] virtual Primitive to_primitive() const = 0;
+    SQ_ND virtual Primitive to_primitive() const = 0;
 
     Field(const Field&) = delete;
     Field(Field&&) = delete;

--- a/src/common_types/include/common_types/FieldCallParams.h
+++ b/src/common_types/include/common_types/FieldCallParams.h
@@ -7,7 +7,6 @@
 #define SQ_INCLUDE_GUARD_common_types_FieldCallParams_h_
 
 #include "common_types/Primitive.h"
-
 #include "util/typeutil.h"
 
 #include <map>
@@ -41,16 +40,16 @@ public:
     /**
      * Get the positional parameters for the field access.
      */
-    [[nodiscard]] PosParams& pos_params();
-    [[nodiscard]] const PosParams& pos_params() const;
+    SQ_ND PosParams& pos_params();
+    SQ_ND const PosParams& pos_params() const;
     ///@}
 
     ///@{
     /**
      * Get the named parameters for the field access
      */
-    [[nodiscard]] NamedParams& named_params();
-    [[nodiscard]] const NamedParams& named_params() const;
+    SQ_ND NamedParams& named_params();
+    SQ_ND const NamedParams& named_params() const;
     ///@}
 
     /**
@@ -60,8 +59,8 @@ public:
      * If the parameter is present but is not of the requested type then an
      * ArgumentTypeError is thrown.
      */
-    template <util::Alternative<Primitive> ParamType>
-    [[nodiscard]] const ParamType& get(size_t index, std::string_view name) const;
+    template <PrimitiveAlternative ParamType>
+    SQ_ND const ParamType& get(size_t index, std::string_view name) const;
 
     /**
      * Get an optional parameter given its name, index and type.
@@ -70,8 +69,8 @@ public:
      * ArgumentTypeError if the parameter is present but is not of the
      * requested type.
      */
-    template <util::Alternative<Primitive> ParamType>
-    [[nodiscard]] const ParamType* get_optional(size_t index, std::string_view name) const;
+    template <PrimitiveAlternative ParamType>
+    SQ_ND const ParamType* get_optional(size_t index, std::string_view name) const;
 
     /**
      * Get an optional parameter if it is present, else return a default value.
@@ -82,8 +81,8 @@ public:
      * Throws ArgumentTypeError if the parameter is present but is not of the
      * requested type.
      */
-    template <util::Alternative<Primitive> ParamType>
-    [[nodiscard]] const ParamType& get_or(
+    template <PrimitiveAlternative ParamType>
+    SQ_ND const ParamType& get_or(
         size_t index,
         std::string_view name,
         const ParamType& default_value
@@ -96,8 +95,8 @@ private:
 };
 
 std::ostream& operator <<(std::ostream& os, const FieldCallParams& params);
-[[nodiscard]] bool operator==(const FieldCallParams& lhs, const FieldCallParams& rhs);
-[[nodiscard]] bool operator!=(const FieldCallParams& lhs, const FieldCallParams& rhs);
+SQ_ND bool operator==(const FieldCallParams& lhs, const FieldCallParams& rhs);
+SQ_ND bool operator!=(const FieldCallParams& lhs, const FieldCallParams& rhs);
 
 } // namespace sq
 

--- a/src/common_types/include/common_types/FieldCallParams.inl.h
+++ b/src/common_types/include/common_types/FieldCallParams.inl.h
@@ -14,7 +14,7 @@
 
 namespace sq {
 
-template <util::Alternative<Primitive> ParamType>
+template <PrimitiveAlternative ParamType>
 const ParamType& FieldCallParams::get(size_t index, std::string_view name) const
 {
     if (index < pos_params_.size())
@@ -47,7 +47,7 @@ const ParamType& FieldCallParams::get(size_t index, std::string_view name) const
     }
 }
 
-template <util::Alternative<Primitive> ParamType>
+template <PrimitiveAlternative ParamType>
 const ParamType* FieldCallParams::get_optional(size_t index, std::string_view name) const
 {
     try
@@ -60,7 +60,7 @@ const ParamType* FieldCallParams::get_optional(size_t index, std::string_view na
     }
 }
 
-template <util::Alternative<Primitive> ParamType>
+template <PrimitiveAlternative ParamType>
 const ParamType& FieldCallParams::get_or(
     size_t index,
     std::string_view name,

--- a/src/common_types/include/common_types/Primitive.h
+++ b/src/common_types/include/common_types/Primitive.h
@@ -27,18 +27,21 @@ using Primitive = std::variant<
     PrimitiveBool
 >;
 
-template <util::Alternative<Primitive> P>
+template <typename T>
+concept PrimitiveAlternative = util::Alternative<T, Primitive>;
+
+template <typename T>
+concept PrimitiveLike = util::ConvertibleToAlternative<T, Primitive>;
+
+template <PrimitiveAlternative P>
 struct PrimitiveTypeName;
 
-template <util::Alternative<Primitive> P>
+template <PrimitiveAlternative P>
 inline constexpr std::string_view primitive_type_name_v = PrimitiveTypeName<P>::value;
 
-[[nodiscard]] std::string_view primitive_type_name(const Primitive& value);
-
-[[nodiscard]] std::string primitive_to_str(const Primitive& value);
-
-template <util::Alternative<Primitive> T>
-[[nodiscard]] std::string primitive_to_str(const T& value);
+SQ_ND std::string_view primitive_type_name(const Primitive& value);
+SQ_ND std::string primitive_to_str(const Primitive& value);
+SQ_ND std::string primitive_to_str(const PrimitiveAlternative auto& value);
 
 } // namespace sq
 

--- a/src/common_types/include/common_types/Primitive.inl.h
+++ b/src/common_types/include/common_types/Primitive.inl.h
@@ -6,15 +6,15 @@
 #ifndef SQ_INCLUDE_GUARD_common_types_Primitive_inl_h_
 #define SQ_INCLUDE_GUARD_common_types_Primitive_inl_h_
 
+#include "util/typeutil.h"
+
 #include <iomanip>
 #include <sstream>
 #include <string_view>
 
-#include "util/typeutil.h"
-
 namespace sq {
 
-template <util::Alternative<Primitive> P>
+template <PrimitiveAlternative P>
 struct PrimitiveTypeName
 { };
 
@@ -46,20 +46,19 @@ namespace detail {
 
 struct PrimitiveToStrVisitor
 {
-    [[nodiscard]] std::string operator()(const PrimitiveString& value)
+    SQ_ND std::string operator()(const PrimitiveString& value)
     {
         os_ << std::quoted(value);
         return os_.str();
     }
 
-    [[nodiscard]] std::string operator()(PrimitiveBool value)
+    SQ_ND std::string operator()(PrimitiveBool value)
     {
         os_ << std::boolalpha << value;
         return os_.str();
     }
 
-    template <util::Alternative<Primitive> T>
-    [[nodiscard]] std::string operator()(const T& value)
+    SQ_ND std::string operator()(const PrimitiveAlternative auto& value)
     {
         os_ << value;
         return os_.str();
@@ -71,8 +70,7 @@ private:
 
 } // namespace detail
 
-template <util::Alternative<Primitive> T>
-std::string primitive_to_str(const T& value)
+std::string primitive_to_str(const PrimitiveAlternative auto& value)
 {
     return detail::PrimitiveToStrVisitor{}(value);
 }

--- a/src/common_types/include/common_types/Token.h
+++ b/src/common_types/include/common_types/Token.h
@@ -6,6 +6,8 @@
 #ifndef SQ_INCLUDE_GUARD_common_types_Token_h_
 #define SQ_INCLUDE_GUARD_common_types_Token_h_
 
+#include "util/typeutil.h"
+
 #include <gsl/gsl>
 #include <iosfwd>
 #include <regex>
@@ -78,28 +80,28 @@ public:
     /**
      * Get the full query string in which the token was found.
      */
-    [[nodiscard]] std::string_view query() const noexcept;
+    SQ_ND std::string_view query() const noexcept;
 
     /**
      * Get the character position within the query at which the token was
      * found.
      */
-    [[nodiscard]] gsl::index pos() const noexcept;
+    SQ_ND gsl::index pos() const noexcept;
 
     /**
      * Get the length, in characters, of the token.
      */
-    [[nodiscard]] gsl::index len() const noexcept;
+    SQ_ND gsl::index len() const noexcept;
 
     /**
      * Get a std::string_view pointing to the characters of the token.
      */
-    [[nodiscard]] std::string_view view() const noexcept;
+    SQ_ND std::string_view view() const noexcept;
 
     /**
      * Get the kind of the token.
      */
-    [[nodiscard]] Kind kind() const noexcept;
+    SQ_ND Kind kind() const noexcept;
 
 private:
     std::string_view query_;

--- a/src/common_types/src/LexError.cpp
+++ b/src/common_types/src/LexError.cpp
@@ -14,7 +14,7 @@ namespace sq {
 
 namespace {
 
-[[nodiscard]] std::string lex_error_message(
+SQ_ND std::string lex_error_message(
     gsl::index pos,
     std::string_view query
 )

--- a/src/common_types/src/OutOfRangeError.cpp
+++ b/src/common_types/src/OutOfRangeError.cpp
@@ -15,7 +15,7 @@ namespace sq {
 
 namespace {
 
-[[nodiscard]] std::string create_oor_message(
+SQ_ND std::string create_oor_message(
     const Token& token,
     std::string_view message
 )

--- a/src/common_types/src/ParseError.cpp
+++ b/src/common_types/src/ParseError.cpp
@@ -14,7 +14,7 @@ namespace sq {
 
 namespace {
 
-[[nodiscard]] std::string create_parse_error_message(
+SQ_ND std::string create_parse_error_message(
     const Token& token,
     const Token::KindSet& expecting
 )

--- a/src/common_types/src/Primitive.cpp
+++ b/src/common_types/src/Primitive.cpp
@@ -12,10 +12,9 @@ namespace {
 
 struct PrimitiveTypeNameVisitor
 {
-    template <util::Alternative<Primitive> T>
-    [[nodiscard]] std::string_view operator()([[maybe_unused]] const T& value) const
+    SQ_ND std::string_view operator()(SQ_MU const PrimitiveAlternative auto& value) const
     {
-        return primitive_type_name_v<T>;
+        return primitive_type_name_v<std::remove_cvref_t<decltype(value)>>;
     }
 };
 

--- a/src/common_types/test/include/test/FieldCallParams_test_util.h
+++ b/src/common_types/test/include/test/FieldCallParams_test_util.h
@@ -16,11 +16,8 @@ namespace sq::test {
 using PosParam = FieldCallParams::PosParams::value_type;
 using NamedParam = FieldCallParams::NamedParams::value_type;
 
-template <typename... Args>
-[[nodiscard]] FieldCallParams params(Args&&... args);
-
-template <util::ConvertibleToAlternative<Primitive> T>
-[[nodiscard]] NamedParam named(std::string_view name, T&& np);
+SQ_ND FieldCallParams params(auto&&... args);
+SQ_ND NamedParam named(std::string_view name, PrimitiveLike auto&& np);
 
 } // namespace sq::test
 

--- a/src/common_types/test/include/test/FieldCallParams_test_util.inl.h
+++ b/src/common_types/test/include/test/FieldCallParams_test_util.inl.h
@@ -16,10 +16,9 @@ namespace sq::test {
 
 namespace detail {
 
-template <util::ConvertibleToAlternative<Primitive> T>
-void add_params(FieldCallParams& fcp, T&& p)
+void add_params(FieldCallParams& fcp, PrimitiveLike auto&& p)
 {
-    fcp.pos_params().emplace_back(to_primitive(std::forward<T>(p)));
+    fcp.pos_params().emplace_back(to_primitive(SQ_FWD(p)));
 }
 
 inline void add_params(FieldCallParams& fcp, NamedParam&& p)
@@ -27,27 +26,24 @@ inline void add_params(FieldCallParams& fcp, NamedParam&& p)
     fcp.named_params().emplace(std::move(p));
 }
 
-template <typename T, typename... Args>
-void add_params(FieldCallParams& fct, T&& p, Args&&... args)
+void add_params(FieldCallParams& fct, auto&& p, auto&&... args)
 {
-    add_params(fct, std::forward<T>(p));
-    add_params(fct, std::forward<Args>(args)...);
+    add_params(fct, SQ_FWD(p));
+    add_params(fct, SQ_FWD(args)...);
 }
 
 } // namespace detail
 
-template <typename... Args>
-FieldCallParams params(Args&&... args)
+FieldCallParams params(auto&&... args)
 {
     auto ret = FieldCallParams{};
-    detail::add_params(ret, std::forward<Args>(args)...);
+    detail::add_params(ret, SQ_FWD(args)...);
     return ret;
 }
 
-template <util::ConvertibleToAlternative<Primitive> T>
-NamedParam named(std::string_view name, T&& np)
+NamedParam named(std::string_view name, PrimitiveLike auto&& np)
 {
-    return NamedParam{name, to_primitive(std::forward<T>(np))};
+    return NamedParam{name, to_primitive(SQ_FWD(np))};
 }
 
 } // namespace sq::test

--- a/src/common_types/test/include/test/Primitive_test_util.h
+++ b/src/common_types/test/include/test/Primitive_test_util.h
@@ -7,20 +7,21 @@
 #define SQ_INCLUDE_GUARD_common_types_test_Primitive_test_util_h_
 
 #include "common_types/Primitive.h"
+#include "util/typeutil.h"
 
 #include <gsl/gsl>
 #include <string_view>
 
 namespace sq::test {
 
-[[nodiscard]] Primitive to_primitive(PrimitiveString&& v);
-[[nodiscard]] Primitive to_primitive(const PrimitiveString& v);
-[[nodiscard]] Primitive to_primitive(std::string_view v);
-[[nodiscard]] Primitive to_primitive(gsl::czstring<> v);
-[[nodiscard]] Primitive to_primitive(PrimitiveInt v);
-[[nodiscard]] Primitive to_primitive(int v);
-[[nodiscard]] Primitive to_primitive(PrimitiveFloat v);
-[[nodiscard]] Primitive to_primitive(PrimitiveBool v);
+SQ_ND Primitive to_primitive(PrimitiveString&& v);
+SQ_ND Primitive to_primitive(const PrimitiveString& v);
+SQ_ND Primitive to_primitive(std::string_view v);
+SQ_ND Primitive to_primitive(gsl::czstring<> v);
+SQ_ND Primitive to_primitive(PrimitiveInt v);
+SQ_ND Primitive to_primitive(int v);
+SQ_ND Primitive to_primitive(PrimitiveFloat v);
+SQ_ND Primitive to_primitive(PrimitiveBool v);
 
 } // namespace sq::test
 

--- a/src/parser/include/parser/Ast.h
+++ b/src/parser/include/parser/Ast.h
@@ -9,6 +9,7 @@
 #include "common_types/FieldCallParams.h"
 #include "parser/FilterSpec.h"
 #include "util/MoveOnlyTree.h"
+#include "util/typeutil.h"
 
 #include <iosfwd>
 #include <string>
@@ -52,22 +53,22 @@ public:
     /**
      * Name of the field being accessed.
      */
-    [[nodiscard]] const std::string& name() const { return name_; }
+    SQ_ND const std::string& name() const { return name_; }
 
     ///@{
     /**
      * Params to pass to the system when accessing the field.
      */
-    [[nodiscard]] const FieldCallParams& params() const { return params_; }
-    [[nodiscard]] FieldCallParams& params() { return params_; }
+    SQ_ND const FieldCallParams& params() const { return params_; }
+    SQ_ND FieldCallParams& params() { return params_; }
     ///@}
 
     ///@{
     /**
      * Details of the filter specified for the results of accessing the field.
      */
-    [[nodiscard]] const FilterSpec& filter_spec() const { return filter_spec_; }
-    [[nodiscard]] FilterSpec& filter_spec() { return filter_spec_; }
+    SQ_ND const FilterSpec& filter_spec() const { return filter_spec_; }
+    SQ_ND FilterSpec& filter_spec() { return filter_spec_; }
     ///@}
 
 private:
@@ -76,8 +77,8 @@ private:
     FilterSpec filter_spec_;
 };
 std::ostream& operator<<(std::ostream& os, const AstData& ast_data);
-[[nodiscard]] bool operator==(const AstData& lhs, const AstData& rhs);
-[[nodiscard]] bool operator!=(const AstData& lhs, const AstData& rhs);
+SQ_ND bool operator==(const AstData& lhs, const AstData& rhs);
+SQ_ND bool operator!=(const AstData& lhs, const AstData& rhs);
 
 using Ast = util::MoveOnlyTree<AstData>;
 

--- a/src/parser/include/parser/FilterSpec.h
+++ b/src/parser/include/parser/FilterSpec.h
@@ -7,6 +7,7 @@
 #define SQ_INCLUDE_GUARD_parser_FilterSpec_h_
 
 #include "common_types/Primitive.h"
+#include "util/typeutil.h"
 
 #include <gsl/gsl>
 #include <iosfwd>
@@ -20,8 +21,8 @@ namespace sq::parser {
  */
 struct NoFilterSpec { };
 std::ostream& operator<<(std::ostream& os, NoFilterSpec nlfs);
-[[nodiscard]] bool operator==(NoFilterSpec lhs, NoFilterSpec rhs);
-[[nodiscard]] bool operator!=(NoFilterSpec lhs, NoFilterSpec rhs);
+SQ_ND bool operator==(NoFilterSpec lhs, NoFilterSpec rhs);
+SQ_ND bool operator!=(NoFilterSpec lhs, NoFilterSpec rhs);
 
 /**
  * Represents access of an indexed element in a list of results for a field
@@ -32,8 +33,8 @@ struct ElementAccessSpec
     gsl::index index_;
 };
 std::ostream& operator<<(std::ostream& os, ElementAccessSpec leas);
-[[nodiscard]] bool operator==(ElementAccessSpec lhs, ElementAccessSpec rhs);
-[[nodiscard]] bool operator!=(ElementAccessSpec lhs, ElementAccessSpec rhs);
+SQ_ND bool operator==(ElementAccessSpec lhs, ElementAccessSpec rhs);
+SQ_ND bool operator!=(ElementAccessSpec lhs, ElementAccessSpec rhs);
 
 /**
  * Represents a Python-style slice of a list of results for a field access.
@@ -45,8 +46,8 @@ struct SliceSpec
     std::optional<gsl::index> step_;
 };
 std::ostream& operator<<(std::ostream& os, SliceSpec lss);
-[[nodiscard]] bool operator==(const SliceSpec& lhs, const SliceSpec& rhs);
-[[nodiscard]] bool operator!=(const SliceSpec& lhs, const SliceSpec& rhs);
+SQ_ND bool operator==(const SliceSpec& lhs, const SliceSpec& rhs);
+SQ_ND bool operator!=(const SliceSpec& lhs, const SliceSpec& rhs);
 
 enum class ComparisonOperator
 {
@@ -68,8 +69,8 @@ struct ComparisonSpec
 
 std::ostream& operator<<(std::ostream& os, const ComparisonOperator& op);
 std::ostream& operator<<(std::ostream& os, const ComparisonSpec& cs);
-[[nodiscard]] bool operator==(const ComparisonSpec& lhs, const ComparisonSpec& rhs);
-[[nodiscard]] bool operator!=(const ComparisonSpec& lhs, const ComparisonSpec& rhs);
+SQ_ND bool operator==(const ComparisonSpec& lhs, const ComparisonSpec& rhs);
+SQ_ND bool operator!=(const ComparisonSpec& lhs, const ComparisonSpec& rhs);
 
 using FilterSpec = std::variant<
     NoFilterSpec,

--- a/src/parser/include/parser/Parser.h
+++ b/src/parser/include/parser/Parser.h
@@ -10,6 +10,7 @@
 #include "common_types/Token.h"
 #include "parser/Ast.h"
 #include "parser/TokenView.h"
+#include "util/typeutil.h"
 
 #include <concepts>
 #include <optional>
@@ -32,34 +33,34 @@ public:
     /**
      * Generate an AST for the input query.
      */
-    [[nodiscard]] Ast parse();
+    SQ_ND Ast parse();
 
 private:
-    [[nodiscard]] bool parse_query(Ast& parent);
-    [[nodiscard]] bool parse_field_tree_list(Ast& parent);
-    [[nodiscard]] bool parse_field_tree(Ast& parent);
-    [[nodiscard]] bool parse_brace_expression(Ast& parent);
-    [[nodiscard]] Ast* parse_dot_expression(Ast& parent);
-    [[nodiscard]] bool parse_field_call(Ast& parent);
-    [[nodiscard]] bool parse_parameter_pack(Ast& parent);
-    [[nodiscard]] bool parse_parameter_list(Ast& parent);
-    [[nodiscard]] bool parse_parameter(Ast& parent);
-    [[nodiscard]] std::optional<Primitive> parse_primitive_value();
-    [[nodiscard]] std::optional<PrimitiveString> parse_dqstring();
-    [[nodiscard]] std::optional<PrimitiveBool> parse_bool();
-    [[nodiscard]] std::optional<PrimitiveFloat> parse_float();
-    [[nodiscard]] bool parse_named_parameter(Ast& parent);
-    [[nodiscard]] bool parse_list_filter(Ast& parent);
-    [[nodiscard]] bool parse_slice_or_element_access(Ast& parent);
-    [[nodiscard]] bool parse_condition(Ast& parent);
-    [[nodiscard]] std::optional<ComparisonOperator> parse_comparison_operator();
+    SQ_ND bool parse_query(Ast& parent);
+    SQ_ND bool parse_field_tree_list(Ast& parent);
+    SQ_ND bool parse_field_tree(Ast& parent);
+    SQ_ND bool parse_brace_expression(Ast& parent);
+    SQ_ND Ast* parse_dot_expression(Ast& parent);
+    SQ_ND bool parse_field_call(Ast& parent);
+    SQ_ND bool parse_parameter_pack(Ast& parent);
+    SQ_ND bool parse_parameter_list(Ast& parent);
+    SQ_ND bool parse_parameter(Ast& parent);
+    SQ_ND std::optional<Primitive> parse_primitive_value();
+    SQ_ND std::optional<PrimitiveString> parse_dqstring();
+    SQ_ND std::optional<PrimitiveBool> parse_bool();
+    SQ_ND std::optional<PrimitiveFloat> parse_float();
+    SQ_ND bool parse_named_parameter(Ast& parent);
+    SQ_ND bool parse_list_filter(Ast& parent);
+    SQ_ND bool parse_slice_or_element_access(Ast& parent);
+    SQ_ND bool parse_condition(Ast& parent);
+    SQ_ND std::optional<ComparisonOperator> parse_comparison_operator();
 
     template <std::integral Int>
-    [[nodiscard]] std::optional<Int> parse_integer();
+    SQ_ND std::optional<Int> parse_integer();
 
     void shift_token();
-    [[nodiscard]] std::optional<Token> accept_token(Token::Kind kind);
-    [[nodiscard]] Token expect_token(Token::Kind kind);
+    SQ_ND std::optional<Token> accept_token(Token::Kind kind);
+    SQ_ND Token expect_token(Token::Kind kind);
 
     TokenView tokens_;
     Token::KindSet expecting_;

--- a/src/parser/include/parser/TokenView.h
+++ b/src/parser/include/parser/TokenView.h
@@ -7,6 +7,7 @@
 #define SQ_INCLUDE_GUARD_parser_TokenView_h_
 
 #include "common_types/Token.h"
+#include "util/typeutil.h"
 
 #include <gsl/gsl>
 #include <optional>
@@ -34,8 +35,8 @@ public:
     // required for ranges::view_facade
     friend ranges::range_access;
 
-    [[nodiscard]] const Token& read() const;
-    [[nodiscard]] bool equal(ranges::default_sentinel_t other) const noexcept;
+    SQ_ND const Token& read() const;
+    SQ_ND bool equal(ranges::default_sentinel_t other) const noexcept;
     void next();
 
 private:

--- a/src/parser/src/FilterSpec.cpp
+++ b/src/parser/src/FilterSpec.cpp
@@ -8,6 +8,7 @@
 #include "common_types/Primitive.h"
 #include "util/ASSERT.h"
 #include "util/strutil.h"
+#include "util/typeutil.h"
 
 #include <iostream>
 
@@ -32,17 +33,17 @@ const char* comparison_operator_to_str(ComparisonOperator op)
 } // namespace
 
 
-std::ostream& operator<<(std::ostream& os, [[maybe_unused]] NoFilterSpec nlfs)
+std::ostream& operator<<(std::ostream& os, SQ_MU NoFilterSpec nlfs)
 {
     return os;
 }
 
-bool operator==([[maybe_unused]] NoFilterSpec lhs, [[maybe_unused]] NoFilterSpec rhs)
+bool operator==(SQ_MU NoFilterSpec lhs, SQ_MU NoFilterSpec rhs)
 {
     return true;
 }
 
-bool operator!=([[maybe_unused]] NoFilterSpec lhs, [[maybe_unused]] NoFilterSpec rhs)
+bool operator!=(SQ_MU NoFilterSpec lhs, SQ_MU NoFilterSpec rhs)
 {
     return !(lhs == rhs);
 }

--- a/src/parser/src/TokenView.cpp
+++ b/src/parser/src/TokenView.cpp
@@ -124,7 +124,7 @@ gsl::index TokenView::whitespace_length() const
 }
 
 bool TokenView::equal(
-    [[maybe_unused]] ranges::default_sentinel_t other
+    SQ_MU ranges::default_sentinel_t other
 ) const noexcept
 {
     return pos_ == -1;

--- a/src/results/include/results/Filter.h
+++ b/src/results/include/results/Filter.h
@@ -8,6 +8,7 @@
 
 #include "common_types/Field.h"
 #include "parser/FilterSpec.h"
+#include "util/typeutil.h"
 
 #include <gsl/gsl>
 #include <memory>
@@ -22,12 +23,12 @@ struct Filter
     /**
      * Create a Filter for the given spec.
      */
-    [[nodiscard]] static FilterPtr create(const parser::FilterSpec& spec);
+    SQ_ND static FilterPtr create(const parser::FilterSpec& spec);
 
     /**
      * Apply this filter to a Result.
      */
-    [[nodiscard]] virtual Result operator()(Result&& result) const = 0;
+    SQ_ND virtual Result operator()(Result&& result) const = 0;
 
     virtual ~Filter() = default;
     Filter() = default;

--- a/src/results/include/results/results.h
+++ b/src/results/include/results/results.h
@@ -9,6 +9,7 @@
 #include "common_types/Field.h"
 #include "common_types/Primitive.h"
 #include "parser/Ast.h"
+#include "util/typeutil.h"
 
 #include <string>
 #include <utility>
@@ -46,16 +47,19 @@ public:
     /**
      * Get the data associated with this node.
      */
-    [[nodiscard]] const Data& data() const { return data_; }
-    [[nodiscard]] Data& data() { return data_; }
+    SQ_ND const Data& data() const { return data_; }
+    SQ_ND Data& data() { return data_; }
     ///@}
 
 private:
     Data data_;
 };
 
-[[nodiscard]] bool operator==(const ResultTree& lhs, const ResultTree& rhs);
-[[nodiscard]] bool operator!=(const ResultTree& lhs, const ResultTree& rhs);
+template <typename T>
+concept ResultTreeDataAlternative = util::Alternative<T, ResultTree::Data>;
+
+SQ_ND bool operator==(const ResultTree& lhs, const ResultTree& rhs);
+SQ_ND bool operator!=(const ResultTree& lhs, const ResultTree& rhs);
 
 } // namespace sq::results
 

--- a/src/results/src/results.cpp
+++ b/src/results/src/results.cpp
@@ -6,6 +6,7 @@
 #include "results/results.h"
 
 #include "results/Filter.h"
+#include "util/typeutil.h"
 
 #include <gsl/gsl>
 
@@ -28,10 +29,8 @@ public:
         : ast_{&ast}
     { }
 
-    [[nodiscard]] Data operator()(FieldPtr&& field) const;
-
-    template <ranges::category Cat>
-    [[nodiscard]] Data operator()(FieldRange<Cat>&& rng) const;
+    SQ_ND Data operator()(FieldPtr&& field) const;
+    SQ_ND Data operator()(ranges::cpp20::view auto&& rng) const;
 
 private:
     gsl::not_null<const parser::Ast*> ast_;
@@ -60,11 +59,10 @@ Data ResultToDataVisitor::operator()(FieldPtr&& field) const
     return obj;
 }
 
-template <ranges::category Cat>
-Data ResultToDataVisitor::operator()(FieldRange<Cat>&& rng) const
+Data ResultToDataVisitor::operator()(ranges::cpp20::view auto&& rng) const
 {
     auto arr = ArrayData{};
-    for (auto field : std::move(rng))
+    for (auto field : SQ_FWD(rng))
     {
         arr.emplace_back(*ast_, std::move(field));
     }

--- a/src/results/test/include/test/results_test_util.h
+++ b/src/results/test/include/test/results_test_util.h
@@ -3,6 +3,7 @@
 
 #include "results/results.h"
 #include "test/Primitive_test_util.h"
+#include "util/typeutil.h"
 
 #include <functional>
 #include <gmock/gmock.h>
@@ -19,6 +20,7 @@ using Data = ResultTree::Data;
 using ObjData = ResultTree::ObjData;
 using ObjDataField = ObjData::value_type;
 using ArrayData = ResultTree::ArrayData;
+using results::ResultTreeDataAlternative;
 
 /**
  * Represents a Field upon whose accesses we have expectations.
@@ -71,11 +73,9 @@ struct FakeField
         Result(std::string_view, const FieldCallParams&)
     >;
 
-    template <util::ConvertibleToAlternative<Primitive> T>
-    FakeField(ResultGenerator result_generator, T&& primitive);
+    FakeField(ResultGenerator result_generator, PrimitiveLike auto&& primitive);
 
-    template <util::ConvertibleToAlternative<Primitive> T>
-    FakeField(T&& primitive);
+    FakeField(PrimitiveLike auto&& primitive);
 
     FakeField(Result&& result);
     FakeField(ResultGenerator result_generator);
@@ -86,12 +86,12 @@ struct FakeField
     FakeField& operator=(FakeField&&) = delete;
     ~FakeField() noexcept = default;
 
-    [[nodiscard]] Result get(
+    SQ_ND Result get(
         std::string_view member,
         const FieldCallParams& params
     ) const override;
 
-    [[nodiscard]] Primitive to_primitive() const override;
+    SQ_ND Primitive to_primitive() const override;
 
 private:
     ResultGenerator result_generator_;
@@ -102,8 +102,7 @@ private:
  * Place an expectation on a mock field that its to_primitive() method will be
  * called exactly once and will return the given value.
  */
-template <util::ConvertibleToAlternative<Primitive> T>
-void expect_one_primitive_access(MockField& mf, T&& retval);
+void expect_one_primitive_access(MockField& mf, PrimitiveLike auto&& retval);
 
 /**
  * Place an expectation on a mock field that its fields will be called
@@ -120,44 +119,39 @@ void expect_field_accesses(
  * Place an expectation on a mock field that its fields will be called
  * according to the given call specifications.
  */
-template <typename... Args>
 void expect_field_accesses(
     MockField& mf,
     std::string_view field_name,
     const FieldCallParams& params,
     Result&& retval,
-    Args&&... args
+    auto&&... args
 );
 
 /**
  * Create a MockField whose only access is expected to be one call to
  * to_primitive().
  */
-template <util::ConvertibleToAlternative<Primitive> T>
-[[nodiscard]] StrictMockFieldPtr field_with_one_primitive_access(T&& retval);
+SQ_ND StrictMockFieldPtr field_with_one_primitive_access(PrimitiveLike auto&& retval);
 
 /**
  * Create a MockField whose only accesses are expected to be the calls in the
  * given specs.
  */
-template <typename... Args>
-[[nodiscard]] StrictMockFieldPtr field_with_accesses(Args&&... args);
+SQ_ND StrictMockFieldPtr field_with_accesses(auto&&... args);
 
 /**
  * Create a ResultTree representing an object with the given field names and
  * values.
  */
-template <typename... Args>
-[[nodiscard]] ResultTree obj_data_tree(Args&&... args);
+SQ_ND ResultTree obj_data_tree(auto&&... args);
 
 /**
  * Create a ResultTree representing an array with the given values.
  */
 template <util::ConvertibleToAlternative<ResultTree::Data>... Args>
-[[nodiscard]] ResultTree array_data_tree(Args&&... args);
+SQ_ND ResultTree array_data_tree(Args&&... args);
 
-template <util::ConvertibleToAlternative<Primitive> T>
-[[nodiscard]] ResultTree primitive_tree(T&& primitive);
+SQ_ND ResultTree primitive_tree(PrimitiveLike auto&& primitive);
 
 inline constexpr auto input = ranges::category::input;
 inline constexpr auto forward = ranges::category::forward;
@@ -173,8 +167,7 @@ inline constexpr auto all_categories = {
 };
 
 
-template <ranges::cpp20::view T>
-[[nodiscard]] Result to_field_range(ranges::category cat, T&& rng);
+SQ_ND Result to_field_range(ranges::category cat, ranges::cpp20::view auto&& rng);
 
 } // namespace sq::test
 

--- a/src/results/test/include/test/results_test_util.inl.h
+++ b/src/results/test/include/test/results_test_util.inl.h
@@ -12,54 +12,48 @@
 
 namespace sq::test {
 
-template <util::ConvertibleToAlternative<Primitive> T>
-FakeField::FakeField(ResultGenerator result_generator, T&& primitive)
+FakeField::FakeField(ResultGenerator result_generator, PrimitiveLike auto&& primitive)
     : result_generator_{result_generator}
-    , primitive_{test::to_primitive(std::forward<T>(primitive))}
+    , primitive_{test::to_primitive(SQ_FWD(primitive))}
 { }
 
-template <util::ConvertibleToAlternative<Primitive> T>
-FakeField::FakeField(T&& primitive)
+FakeField::FakeField(PrimitiveLike auto&& primitive)
     : result_generator_{
         [&](auto, auto) { return std::make_shared<FakeField>(); }
     }
-    , primitive_{test::to_primitive(std::forward<T>(primitive))}
+    , primitive_{test::to_primitive(SQ_FWD(primitive))}
 { }
 
-template <util::ConvertibleToAlternative<Primitive> T>
-void expect_one_primitive_access(MockField& mf, T&& retval)
+void expect_one_primitive_access(MockField& mf, PrimitiveLike auto&& retval)
 {
     EXPECT_CALL(mf, to_primitive())
         .Times(1)
-        .WillOnce(Return(to_primitive(std::forward<T>(retval))));
+        .WillOnce(Return(to_primitive(SQ_FWD(retval))));
 }
 
-template <typename... Args>
 void expect_field_accesses(
     MockField& mf,
     std::string_view field_name,
     const FieldCallParams& params,
     Result&& retval,
-    Args&&... args
+    auto&&... args
 )
 {
     expect_field_accesses(mf, field_name, params, std::move(retval));
-    expect_field_accesses(mf, std::forward<Args>(args)...);
+    expect_field_accesses(mf, SQ_FWD(args)...);
 }
 
-template <util::ConvertibleToAlternative<Primitive> T>
-StrictMockFieldPtr field_with_one_primitive_access(T&& retval)
+StrictMockFieldPtr field_with_one_primitive_access(PrimitiveLike auto&& retval)
 {
     auto mf = std::make_shared<testing::StrictMock<MockField>>();
-    expect_one_primitive_access(*mf, std::forward<T>(retval));
+    expect_one_primitive_access(*mf, SQ_FWD(retval));
     return mf;
 }
 
-template <typename... Args>
-StrictMockFieldPtr field_with_accesses(Args&&... args)
+StrictMockFieldPtr field_with_accesses(auto&&... args)
 {
     auto mf = std::make_shared<StrictMockField>();
-    expect_field_accesses(*mf, std::forward<Args>(args)...);
+    expect_field_accesses(*mf, SQ_FWD(args)...);
     return mf;
 }
 
@@ -71,61 +65,56 @@ void add_fields_to_obj_data(
     ResultTree&& field_data
 );
 
-template <util::ConvertibleToAlternative<Primitive> T>
 void add_fields_to_obj_data(
     ObjData& obj,
     std::string_view field_name,
-    T&& field_data
+    PrimitiveLike auto&& field_data
 )
 {
     add_fields_to_obj_data(
         obj,
         field_name,
-        ResultTree{to_primitive(std::forward<T>(field_data))}
+        ResultTree{to_primitive(SQ_FWD(field_data))}
     );
 }
 
-template <util::Alternative<ResultTree::Data> T>
 void add_fields_to_obj_data(
     ObjData& obj,
     std::string_view field_name,
-    T&& field_data
+    ResultTreeDataAlternative auto&& field_data
 )
 {
     add_fields_to_obj_data(
         obj,
         field_name,
-        ResultTree{std::forward<T>(field_data)}
+        ResultTree{SQ_FWD(field_data)}
     );
 }
 
-template <typename T, typename... Args>
 void add_fields_to_obj_data(
     ObjData& obj,
     std::string_view field_name,
-    T&& field_data,
-    Args&&... args
+    auto&& field_data,
+    auto&&... args
 )
 {
-    add_fields_to_obj_data(obj, field_name, std::forward<T>(field_data));
-    add_fields_to_obj_data(obj, std::forward<Args>(args)...);
+    add_fields_to_obj_data(obj, field_name, SQ_FWD(field_data));
+    add_fields_to_obj_data(obj, SQ_FWD(args)...);
 }
 
 void add_items_to_array_data(ArrayData& arr, ResultTree&& field_data);
 
-template <util::ConvertibleToAlternative<Primitive> T>
-void add_items_to_array_data(ArrayData& arr, T&& field_data)
+void add_items_to_array_data(ArrayData& arr, PrimitiveLike auto&& field_data)
 {
     add_items_to_array_data(
         arr, 
-        ResultTree{to_primitive(std::forward<T>(field_data))}
+        ResultTree{to_primitive(SQ_FWD(field_data))}
     );
 }
 
-template <util::Alternative<ResultTree::Data> T>
-void add_items_to_array_data(ArrayData& arr, T&& field_data)
+void add_items_to_array_data(ArrayData& arr, ResultTreeDataAlternative auto&& field_data)
 {
-    add_items_to_array_data(arr, ResultTree{std::forward<T>(field_data)});
+    add_items_to_array_data(arr, ResultTree{SQ_FWD(field_data)});
 }
 
 template <util::ConvertibleToAlternative<ResultTree::Data> T, typename... Args>
@@ -135,17 +124,16 @@ void add_items_to_array_data(
     Args&&... args
 )
 {
-    add_items_to_array_data(arr, std::forward<T>(field_data));
-    add_items_to_array_data(arr, std::forward<Args>(args)...);
+    add_items_to_array_data(arr, SQ_FWD(field_data));
+    add_items_to_array_data(arr, SQ_FWD(args)...);
 }
 
 } // namespace detail
 
-template <typename... Args>
-ResultTree obj_data_tree(Args&&... args)
+ResultTree obj_data_tree(auto&&... args)
 {
     auto obj_data = ObjData{};
-    detail::add_fields_to_obj_data(obj_data, std::forward<Args>(args)...);
+    detail::add_fields_to_obj_data(obj_data, SQ_FWD(args)...);
     return ResultTree{std::move(obj_data)};
 }
 
@@ -153,53 +141,51 @@ template <util::ConvertibleToAlternative<ResultTree::Data>... Args>
 ResultTree array_data_tree(Args&&... args)
 {
     auto arr = ArrayData{};
-    detail::add_items_to_array_data(arr, std::forward<Args>(args)...);
+    detail::add_items_to_array_data(arr, SQ_FWD(args)...);
     return ResultTree{std::move(arr)};
 }
 
-template <util::ConvertibleToAlternative<Primitive> T>
-ResultTree primitive_tree(T&& primitive)
+ResultTree primitive_tree(PrimitiveLike auto&& primitive)
 {
-    return ResultTree{to_primitive(std::forward<T>(primitive))};
+    return ResultTree{to_primitive(SQ_FWD(primitive))};
 }
 
-template <ranges::cpp20::view T>
-Result to_field_range(ranges::category cat, T&& rng)
+Result to_field_range(ranges::category cat, ranges::cpp20::view auto&& rng)
 {
     if (cat == input)
     {
-        return FieldRange<input>{std::forward<T>(rng)};
+        return FieldRange<input>{SQ_FWD(rng)};
     }
     if (cat == (input|sized))
     {
-        return FieldRange<input|sized>{std::forward<T>(rng)};
+        return FieldRange<input|sized>{SQ_FWD(rng)};
     }
     if (cat == forward)
     {
-        return FieldRange<forward>{std::forward<T>(rng)};
+        return FieldRange<forward>{SQ_FWD(rng)};
     }
     if (cat == (forward|sized))
     {
-        return FieldRange<forward|sized>{std::forward<T>(rng)};
+        return FieldRange<forward|sized>{SQ_FWD(rng)};
     }
     if (cat == bidirectional)
     {
-        return FieldRange<bidirectional>{std::forward<T>(rng)};
+        return FieldRange<bidirectional>{SQ_FWD(rng)};
     }
     if (cat == (bidirectional|sized))
     {
-        return FieldRange<bidirectional|sized>{std::forward<T>(rng)};
+        return FieldRange<bidirectional|sized>{SQ_FWD(rng)};
     }
     if (cat == random_access)
     {
-        return FieldRange<random_access>{std::forward<T>(rng)};
+        return FieldRange<random_access>{SQ_FWD(rng)};
     }
     if (cat == (random_access|sized))
     {
-        return FieldRange<random_access|sized>{std::forward<T>(rng)};
+        return FieldRange<random_access|sized>{SQ_FWD(rng)};
     }
     ASSERT(false);
-    return FieldRange<input>{std::forward<T>(rng)};
+    return FieldRange<input>{SQ_FWD(rng)};
 }
 
 } // namespace test

--- a/src/system/include/system/CacheingField.h
+++ b/src/system/include/system/CacheingField.h
@@ -6,6 +6,7 @@
 #define SQ_INCLUDE_GUARD_system_CacheingField_h_
 
 #include "common_types/Field.h"
+#include "util/typeutil.h"
 
 #include <map>
 #include <string>
@@ -16,13 +17,13 @@ class CacheingField
     : public Field
 {
 public:
-    [[nodiscard]] Result get(
+    SQ_ND Result get(
         std::string_view member,
         const FieldCallParams& params
     ) const override;
 
 private:
-    [[nodiscard]] virtual Result dispatch(
+    SQ_ND virtual Result dispatch(
         std::string_view member,
         const FieldCallParams& params
     ) const = 0;

--- a/src/system/include/system/root.h
+++ b/src/system/include/system/root.h
@@ -7,10 +7,11 @@
 #define SQ_INCLUDE_GUARD_system_root_h_
 
 #include "common_types/Field.h"
+#include "util/typeutil.h"
 
 namespace sq::system {
 
-[[nodiscard]] FieldPtr root();
+SQ_ND FieldPtr root();
 
 } // namespace sq::system
 

--- a/src/system/include/system/schema.h
+++ b/src/system/include/system/schema.h
@@ -6,6 +6,8 @@
 #ifndef SQ_INCLUDE_GUARD_system_schema_h_
 #define SQ_INCLUDE_GUARD_system_schema_h_
 
+#include "util/typeutil.h"
+
 #include <cstddef>
 #include <gsl/gsl>
 #include <string_view>
@@ -28,8 +30,8 @@ public:
         , doc_{doc}
     { }
 
-    [[nodiscard]] std::string_view name() const;
-    [[nodiscard]] std::string_view doc() const;
+    SQ_ND std::string_view name() const;
+    SQ_ND std::string_view doc() const;
 
 private:
     std::string_view name_;
@@ -54,10 +56,10 @@ public:
         , type_index_{type_index}
     { }
 
-    [[nodiscard]] std::string_view name() const;
-    [[nodiscard]] std::string_view doc() const;
-    [[nodiscard]] std::size_t index() const;
-    [[nodiscard]] const PrimitiveTypeSchema& type() const;
+    SQ_ND std::string_view name() const;
+    SQ_ND std::string_view doc() const;
+    SQ_ND std::size_t index() const;
+    SQ_ND const PrimitiveTypeSchema& type() const;
 
 private:
     std::string_view name_;
@@ -90,11 +92,11 @@ public:
         , return_list_{return_list}
     { }
 
-    [[nodiscard]] std::string_view name() const;
-    [[nodiscard]] std::string_view doc() const;
-    [[nodiscard]] gsl::span<const ParamSchema> params() const;
-    [[nodiscard]] const TypeSchema& return_type() const;
-    [[nodiscard]] bool return_list() const;
+    SQ_ND std::string_view name() const;
+    SQ_ND std::string_view doc() const;
+    SQ_ND gsl::span<const ParamSchema> params() const;
+    SQ_ND const TypeSchema& return_type() const;
+    SQ_ND bool return_list() const;
 
 private:
     std::string_view name_;
@@ -123,9 +125,9 @@ public:
         , fields_end_index_{fields_end_index}
     { }
 
-    [[nodiscard]] std::string_view name() const;
-    [[nodiscard]] std::string_view doc() const;
-    [[nodiscard]] gsl::span<const FieldSchema> fields() const;
+    SQ_ND std::string_view name() const;
+    SQ_ND std::string_view doc() const;
+    SQ_ND gsl::span<const FieldSchema> fields() const;
 
 private:
     std::string_view name_;
@@ -140,9 +142,9 @@ private:
 struct Schema
 {
 public:
-    [[nodiscard]] gsl::span<const TypeSchema> types() const;
-    [[nodiscard]] gsl::span<const PrimitiveTypeSchema> primitive_types() const;
-    [[nodiscard]] const TypeSchema& root_type() const;
+    SQ_ND gsl::span<const TypeSchema> types() const;
+    SQ_ND gsl::span<const PrimitiveTypeSchema> primitive_types() const;
+    SQ_ND const TypeSchema& root_type() const;
 };
 
 /**

--- a/src/system/include/system/standard/SqBoolImpl.h
+++ b/src/system/include/system/standard/SqBoolImpl.h
@@ -7,6 +7,7 @@
 #define SQ_INCLUDE_GUARD_system_standard_SqBoolImpl_h_
 
 #include "system/SqBool.gen.h"
+#include "util/typeutil.h"
 
 namespace sq::system::standard {
 
@@ -16,7 +17,7 @@ class SqBoolImpl
 public:
     explicit SqBoolImpl(PrimitiveBool value);
 
-    [[nodiscard]] Primitive to_primitive() const override;
+    SQ_ND Primitive to_primitive() const override;
 
 private:
     PrimitiveBool value_;

--- a/src/system/include/system/standard/SqDataSizeImpl.h
+++ b/src/system/include/system/standard/SqDataSizeImpl.h
@@ -7,6 +7,7 @@
 #define SQ_INCLUDE_GUARD_system_standard_SqDataSizeImpl_h_
 
 #include "system/SqDataSize.gen.h"
+#include "util/typeutil.h"
 
 #include <cstdint>
 
@@ -18,20 +19,20 @@ class SqDataSizeImpl
 public:
     explicit SqDataSizeImpl(std::size_t value);
 
-    [[nodiscard]] Result get_B() const;
-    [[nodiscard]] Result get_KiB() const;
-    [[nodiscard]] Result get_kB() const;
-    [[nodiscard]] Result get_MiB() const;
-    [[nodiscard]] Result get_MB() const;
-    [[nodiscard]] Result get_GiB() const;
-    [[nodiscard]] Result get_GB() const;
-    [[nodiscard]] Result get_TiB() const;
-    [[nodiscard]] Result get_TB() const;
-    [[nodiscard]] Result get_PiB() const;
-    [[nodiscard]] Result get_PB() const;
-    [[nodiscard]] Result get_EiB() const;
-    [[nodiscard]] Result get_EB() const;
-    [[nodiscard]] Primitive to_primitive() const override;
+    SQ_ND Result get_B() const;
+    SQ_ND Result get_KiB() const;
+    SQ_ND Result get_kB() const;
+    SQ_ND Result get_MiB() const;
+    SQ_ND Result get_MB() const;
+    SQ_ND Result get_GiB() const;
+    SQ_ND Result get_GB() const;
+    SQ_ND Result get_TiB() const;
+    SQ_ND Result get_TB() const;
+    SQ_ND Result get_PiB() const;
+    SQ_ND Result get_PB() const;
+    SQ_ND Result get_EiB() const;
+    SQ_ND Result get_EB() const;
+    SQ_ND Primitive to_primitive() const override;
 
 private:
     std::size_t value_;

--- a/src/system/include/system/standard/SqFieldSchemaImpl.h
+++ b/src/system/include/system/standard/SqFieldSchemaImpl.h
@@ -6,9 +6,9 @@
 #ifndef SQ_INCLUDE_GUARD_system_standard_SqFieldSchemaImpl_h_
 #define SQ_INCLUDE_GUARD_system_standard_SqFieldSchemaImpl_h_
 
-#include "system/SqFieldSchema.gen.h"
-
 #include "system/schema.h"
+#include "system/SqFieldSchema.gen.h"
+#include "util/typeutil.h"
 
 #include <gsl/gsl>
 
@@ -20,13 +20,13 @@ class SqFieldSchemaImpl
 public:
     explicit SqFieldSchemaImpl(const FieldSchema& field_schema);
 
-    [[nodiscard]] Result get_name() const;
-    [[nodiscard]] Result get_doc() const;
-    [[nodiscard]] Result get_params() const;
-    [[nodiscard]] Result get_return_type() const;
-    [[nodiscard]] Result get_return_list() const;
+    SQ_ND Result get_name() const;
+    SQ_ND Result get_doc() const;
+    SQ_ND Result get_params() const;
+    SQ_ND Result get_return_type() const;
+    SQ_ND Result get_return_list() const;
 
-    [[nodiscard]] Primitive to_primitive() const override;
+    SQ_ND Primitive to_primitive() const override;
 
 private:
     gsl::not_null<const FieldSchema*> field_schema_;

--- a/src/system/include/system/standard/SqFloatImpl.h
+++ b/src/system/include/system/standard/SqFloatImpl.h
@@ -7,6 +7,7 @@
 #define SQ_INCLUDE_GUARD_system_standard_SqFloatImpl_h_
 
 #include "system/SqFloat.gen.h"
+#include "util/typeutil.h"
 
 namespace sq::system::standard {
 
@@ -16,7 +17,7 @@ class SqFloatImpl
 public:
     explicit SqFloatImpl(PrimitiveFloat value);
 
-    [[nodiscard]] Primitive to_primitive() const override;
+    SQ_ND Primitive to_primitive() const override;
 
 private:
     PrimitiveFloat value_;

--- a/src/system/include/system/standard/SqIntImpl.h
+++ b/src/system/include/system/standard/SqIntImpl.h
@@ -7,6 +7,7 @@
 #define SQ_INCLUDE_GUARD_system_standard_SqIntImpl_h_
 
 #include "system/SqInt.gen.h"
+#include "util/typeutil.h"
 
 namespace sq::system::standard {
 
@@ -16,7 +17,7 @@ class SqIntImpl
 public:
     explicit SqIntImpl(PrimitiveInt value);
 
-    [[nodiscard]] Primitive to_primitive() const override;
+    SQ_ND Primitive to_primitive() const override;
 
 private:
     PrimitiveInt value_;

--- a/src/system/include/system/standard/SqParamSchemaImpl.h
+++ b/src/system/include/system/standard/SqParamSchemaImpl.h
@@ -6,9 +6,9 @@
 #ifndef SQ_INCLUDE_GUARD_system_standard_SqParamSchemaImpl_h_
 #define SQ_INCLUDE_GUARD_system_standard_SqParamSchemaImpl_h_
 
-#include "system/SqParamSchema.gen.h"
-
 #include "system/schema.h"
+#include "system/SqParamSchema.gen.h"
+#include "util/typeutil.h"
 
 #include <gsl/gsl>
 
@@ -20,12 +20,12 @@ class SqParamSchemaImpl
 public:
     explicit SqParamSchemaImpl(const ParamSchema& param_schema);
 
-    [[nodiscard]] Result get_name() const;
-    [[nodiscard]] Result get_doc() const;
-    [[nodiscard]] Result get_index() const;
-    [[nodiscard]] Result get_type() const;
+    SQ_ND Result get_name() const;
+    SQ_ND Result get_doc() const;
+    SQ_ND Result get_index() const;
+    SQ_ND Result get_type() const;
 
-    [[nodiscard]] Primitive to_primitive() const override;
+    SQ_ND Primitive to_primitive() const override;
 
 private:
     gsl::not_null<const ParamSchema*> param_schema_;

--- a/src/system/include/system/standard/SqPathImpl.h
+++ b/src/system/include/system/standard/SqPathImpl.h
@@ -7,6 +7,7 @@
 #define SQ_INCLUDE_GUARD_system_standard_SqPathImpl_h_
 
 #include "system/SqPath.gen.h"
+#include "util/typeutil.h"
 
 #include <filesystem>
 
@@ -19,18 +20,18 @@ public:
     explicit SqPathImpl(const std::filesystem::path& value);
     explicit SqPathImpl(std::filesystem::path&& value);
 
-    [[nodiscard]] Result get_string() const;
-    [[nodiscard]] Result get_parent() const;
-    [[nodiscard]] Result get_filename() const;
-    [[nodiscard]] Result get_extension() const;
-    [[nodiscard]] Result get_stem() const;
-    [[nodiscard]] Result get_children() const;
-    [[nodiscard]] Result get_parts() const;
-    [[nodiscard]] Result get_absolute() const;
-    [[nodiscard]] Result get_canonical() const;
-    [[nodiscard]] Result get_is_absolute() const;
-    [[nodiscard]] Result get_size() const;
-    [[nodiscard]] Primitive to_primitive() const override;
+    SQ_ND Result get_string() const;
+    SQ_ND Result get_parent() const;
+    SQ_ND Result get_filename() const;
+    SQ_ND Result get_extension() const;
+    SQ_ND Result get_stem() const;
+    SQ_ND Result get_children() const;
+    SQ_ND Result get_parts() const;
+    SQ_ND Result get_absolute() const;
+    SQ_ND Result get_canonical() const;
+    SQ_ND Result get_is_absolute() const;
+    SQ_ND Result get_size() const;
+    SQ_ND Primitive to_primitive() const override;
 
 private:
     std::filesystem::path value_;

--- a/src/system/include/system/standard/SqPrimitiveTypeSchemaImpl.h
+++ b/src/system/include/system/standard/SqPrimitiveTypeSchemaImpl.h
@@ -6,9 +6,9 @@
 #ifndef SQ_INCLUDE_GUARD_system_standard_SqPrimitiveTypeSchemaImpl_h_
 #define SQ_INCLUDE_GUARD_system_standard_SqPrimitiveTypeSchemaImpl_h_
 
-#include "system/SqPrimitiveTypeSchema.gen.h"
-
 #include "system/schema.h"
+#include "system/SqPrimitiveTypeSchema.gen.h"
+#include "util/typeutil.h"
 
 #include <gsl/gsl>
 
@@ -20,10 +20,10 @@ class SqPrimitiveTypeSchemaImpl
 public:
     explicit SqPrimitiveTypeSchemaImpl(const PrimitiveTypeSchema& primitive_type_schema);
 
-    [[nodiscard]] Result get_name() const;
-    [[nodiscard]] Result get_doc() const;
+    SQ_ND Result get_name() const;
+    SQ_ND Result get_doc() const;
 
-    [[nodiscard]] Primitive to_primitive() const override;
+    SQ_ND Primitive to_primitive() const override;
 
 private:
     gsl::not_null<const PrimitiveTypeSchema*> primitive_type_schema_;

--- a/src/system/include/system/standard/SqRootImpl.h
+++ b/src/system/include/system/standard/SqRootImpl.h
@@ -7,6 +7,7 @@
 #define SQ_INCLUDE_GUARD_system_standard_SqRootImpl_h_
 
 #include "system/SqRoot.gen.h"
+#include "util/typeutil.h"
 
 namespace sq::system::standard {
 
@@ -14,13 +15,13 @@ class SqRootImpl
     : public SqRoot<SqRootImpl>
 {
 public:
-    [[nodiscard]] static Result get_schema();
-    [[nodiscard]] static Result get_path(const PrimitiveString* path);
-    [[nodiscard]] static Result get_int(PrimitiveInt value);
-    [[nodiscard]] static Result get_ints(PrimitiveInt start, const PrimitiveInt* stop);
-    [[nodiscard]] static Result get_bool(PrimitiveBool value);
-    [[nodiscard]] static Result get_float(PrimitiveFloat value);
-    [[nodiscard]] Primitive to_primitive() const override;
+    SQ_ND static Result get_schema();
+    SQ_ND static Result get_path(const PrimitiveString* path);
+    SQ_ND static Result get_int(PrimitiveInt value);
+    SQ_ND static Result get_ints(PrimitiveInt start, const PrimitiveInt* stop);
+    SQ_ND static Result get_bool(PrimitiveBool value);
+    SQ_ND static Result get_float(PrimitiveFloat value);
+    SQ_ND Primitive to_primitive() const override;
 };
 
 } // namespace sq::system::standard

--- a/src/system/include/system/standard/SqSchemaImpl.h
+++ b/src/system/include/system/standard/SqSchemaImpl.h
@@ -6,9 +6,9 @@
 #ifndef SQ_INCLUDE_GUARD_system_standard_SqSchemaImpl_h_
 #define SQ_INCLUDE_GUARD_system_standard_SqSchemaImpl_h_
 
-#include "system/SqSchema.gen.h"
-
 #include "system/schema.h"
+#include "system/SqSchema.gen.h"
+#include "util/typeutil.h"
 
 namespace sq::system::standard {
 
@@ -16,11 +16,11 @@ class SqSchemaImpl
     : public SqSchema<SqSchemaImpl>
 {
 public:
-    [[nodiscard]] static Result get_primitive_types();
-    [[nodiscard]] static Result get_types();
-    [[nodiscard]] static Result get_root_type();
+    SQ_ND static Result get_primitive_types();
+    SQ_ND static Result get_types();
+    SQ_ND static Result get_root_type();
 
-    [[nodiscard]] Primitive to_primitive() const override;
+    SQ_ND Primitive to_primitive() const override;
 };
 
 } // namespace sq::system::standard

--- a/src/system/include/system/standard/SqStringImpl.h
+++ b/src/system/include/system/standard/SqStringImpl.h
@@ -7,6 +7,7 @@
 #define SQ_INCLUDE_GUARD_system_standard_SqStringImpl_h_
 
 #include "system/SqString.gen.h"
+#include "util/typeutil.h"
 
 #include <string_view>
 
@@ -19,7 +20,7 @@ public:
     explicit SqStringImpl(std::string_view value);
     explicit SqStringImpl(PrimitiveString&& value);
 
-    [[nodiscard]] Primitive to_primitive() const override;
+    SQ_ND Primitive to_primitive() const override;
 
 private:
     PrimitiveString value_;

--- a/src/system/include/system/standard/SqTypeSchemaImpl.h
+++ b/src/system/include/system/standard/SqTypeSchemaImpl.h
@@ -7,6 +7,7 @@
 #define SQ_INCLUDE_GUARD_system_standard_SqTypeSchemaImpl_h_
 
 #include "system/SqTypeSchema.gen.h"
+#include "util/typeutil.h"
 
 #include "system/schema.h"
 
@@ -20,11 +21,11 @@ class SqTypeSchemaImpl
 public:
     explicit SqTypeSchemaImpl(const TypeSchema& type_schema);
 
-    [[nodiscard]] Result get_name() const;
-    [[nodiscard]] Result get_doc() const;
-    [[nodiscard]] Result get_fields() const;
+    SQ_ND Result get_name() const;
+    SQ_ND Result get_doc() const;
+    SQ_ND Result get_fields() const;
 
-    [[nodiscard]] Primitive to_primitive() const override;
+    SQ_ND Primitive to_primitive() const override;
 
 private:
     gsl::not_null<const TypeSchema*> type_schema_;

--- a/src/system/src/CacheingField.cpp
+++ b/src/system/src/CacheingField.cpp
@@ -1,6 +1,7 @@
 #include "system/CacheingField.h"
 
 #include "util/ASSERT.h"
+#include "util/typeutil.h"
 
 #include <range/v3/range/concepts.hpp>
 
@@ -12,21 +13,20 @@ namespace {
  */
 struct ShouldCache
 {
-    [[nodiscard]] bool operator()(const Result& value) const
+    SQ_ND bool operator()(const Result& value) const
     {
         return std::visit(*this, value);
     }
 
-    [[nodiscard]] bool operator()([[maybe_unused]] const FieldPtr& value) const
+    SQ_ND bool operator()(SQ_MU const FieldPtr& value) const
     {
         return true;
     }
 
-    template <ranges::cpp20::range R>
-    [[nodiscard]] bool operator()([[maybe_unused]] const R& rng) const
+    SQ_ND bool operator()(SQ_MU const ranges::cpp20::range auto& rng) const
     {
         // Don't cache input_ranges - they can only be iterated over once.
-        return ranges::forward_range<R>;
+        return ranges::forward_range<decltype(rng)>;
     }
 };
 

--- a/src/system/templates/SqType.gen.h.template
+++ b/src/system/templates/SqType.gen.h.template
@@ -6,6 +6,7 @@
 #define SQ_INCLUDE_GUARD_system_{{= name }}_gen_h_
 
 #include "system/CacheingField.h"
+#include "util/typeutil.h"
 
 namespace sq::system {
 
@@ -24,7 +25,7 @@ private:
      * I.e. something like calling:
      *       derived_implementation_object->get_[member](params)
      */
-    [[nodiscard]] Result dispatch(
+    SQ_ND Result dispatch(
         std::string_view member,
         const FieldCallParams& params
     ) const override;

--- a/src/system/templates/SqType.gen.inl.h.template
+++ b/src/system/templates/SqType.gen.inl.h.template
@@ -7,13 +7,14 @@
 
 #include "common_types/InvalidFieldError.h"
 #include "common_types/FieldCallParams.h"
+#include "util/typeutil.h"
 
 namespace sq::system {
 
 template <typename Impl>
 Result {{= name }}<Impl>::dispatch(
     std::string_view member,
-    [[maybe_unused]] const FieldCallParams& params
+    SQ_MU const FieldCallParams& params
 ) const
 {
 {{

--- a/src/util/include/util/MoveOnlyTree.h
+++ b/src/util/include/util/MoveOnlyTree.h
@@ -34,31 +34,30 @@ public:
     MoveOnlyTree& operator=(MoveOnlyTree&&) noexcept = default;
     ~MoveOnlyTree() noexcept = default;
 
-    template <typename... Args>
-    explicit MoveOnlyTree(Args&&... args)
-        : data_{std::forward<Args>(args)...}
+    explicit MoveOnlyTree(auto&&... args)
+        : data_{SQ_FWD(args)...}
     { }
 
     ///@{
     /**
      * Get the data associated with this node.
      */
-    [[nodiscard]] const T& data() const noexcept { return data_; }
-    [[nodiscard]] T& data() noexcept { return data_; }
+    SQ_ND const T& data() const noexcept { return data_; }
+    SQ_ND T& data() noexcept { return data_; }
     ///@}
 
     ///@{
     /**
      * Get the child nodes of this node.
      */
-    [[nodiscard]] const Children& children() const noexcept { return children_; }
-    [[nodiscard]] Children& children() noexcept { return children_; }
+    SQ_ND const Children& children() const noexcept { return children_; }
+    SQ_ND Children& children() noexcept { return children_; }
     ///@}
 
-    [[nodiscard]] friend bool operator==(const MoveOnlyTree& lhs, const MoveOnlyTree& rhs) {
+    SQ_ND friend bool operator==(const MoveOnlyTree& lhs, const MoveOnlyTree& rhs) {
         return lhs.children_ == rhs.children_ && lhs.data_ == rhs.data_;
     }
-    [[nodiscard]] friend bool operator!=(const MoveOnlyTree& lhs, const MoveOnlyTree& rhs) {
+    SQ_ND friend bool operator!=(const MoveOnlyTree& lhs, const MoveOnlyTree& rhs) {
         return !(lhs == rhs);
     }
  

--- a/src/util/include/util/strutil.h
+++ b/src/util/include/util/strutil.h
@@ -68,7 +68,7 @@ namespace detail {
 struct VariantToStr
 {
     template <Printable... Types>
-    [[nodiscard]] std::string operator()(const std::variant<Types...>& var) const
+    SQ_ND std::string operator()(const std::variant<Types...> & var) const
     {
         auto ss = std::ostringstream{};
         std::visit(
@@ -82,7 +82,7 @@ struct VariantToStr
 struct OptionalToStr
 {
     template <Printable T>
-    [[nodiscard]] std::string operator()(const std::optional<T>& opt) const
+    SQ_ND std::string operator()(const std::optional<T>& opt) const
     {
         if (opt)
         {


### PR DESCRIPTION
* The [[nodiscard]] and [[maybe_unused]] attributes all over the code
  were too distracting so replace them with shorter macros.
* The std::forward<T>s were distracting too. replace with a shorter
  macro.
* Use abbreviated function templates to reduce distraction by template
  boilerplate.
* Introduce a few concepts to enable abbreviated function templates to
  be used in more places.