### PR TITLE
Add tests for retrieving SQ's schema

### DIFF
--- a/src/system/include/system/schema.h
+++ b/src/system/include/system/schema.h
@@ -39,19 +39,23 @@ private:
 class ParamSchema {
 public:
   constexpr ParamSchema(std::string_view name, std::string_view doc,
-                        std::size_t index, std::size_t type_index)
-      : name_{name}, doc_{doc}, index_{index}, type_index_{type_index} {}
+                        std::size_t index, std::size_t type_index,
+                        bool required)
+      : name_{name}, doc_{doc}, index_{index},
+        type_index_{type_index}, required_{required} {}
 
   SQ_ND std::string_view name() const;
   SQ_ND std::string_view doc() const;
   SQ_ND std::size_t index() const;
   SQ_ND const PrimitiveTypeSchema &type() const;
+  SQ_ND bool required() const;
 
 private:
   std::string_view name_;
   std::string_view doc_;
   std::size_t index_;
   std::size_t type_index_;
+  bool required_;
 };
 
 class TypeSchema;

--- a/src/system/include/system/standard/SqParamSchemaImpl.h
+++ b/src/system/include/system/standard/SqParamSchemaImpl.h
@@ -22,6 +22,7 @@ public:
   SQ_ND Result get_doc() const;
   SQ_ND Result get_index() const;
   SQ_ND Result get_type() const;
+  SQ_ND Result get_required() const;
 
   SQ_ND Primitive to_primitive() const override;
 

--- a/src/system/schema.json
+++ b/src/system/schema.json
@@ -210,6 +210,13 @@
                     "return_type": "SqPrimitiveTypeSchema",
                     "return_list": false,
                     "params": []
+                },
+                {
+                    "name": "required",
+                    "doc": "Whether the parameter is required or not",
+                    "return_type": "SqBool",
+                    "return_list": false,
+                    "params": []
                 }
             ]
         },

--- a/src/system/src/standard/SqParamSchemaImpl.cpp
+++ b/src/system/src/standard/SqParamSchemaImpl.cpp
@@ -5,6 +5,7 @@
 
 #include "system/standard/SqParamSchemaImpl.h"
 
+#include "system/standard/SqBoolImpl.h"
 #include "system/standard/SqIntImpl.h"
 #include "system/standard/SqPrimitiveTypeSchemaImpl.h"
 #include "system/standard/SqStringImpl.h"
@@ -30,6 +31,10 @@ Result SqParamSchemaImpl::get_index() const {
 
 Result SqParamSchemaImpl::get_type() const {
   return std::make_shared<SqPrimitiveTypeSchemaImpl>(param_schema_->type());
+}
+
+Result SqParamSchemaImpl::get_required() const {
+  return std::make_shared<SqBoolImpl>(param_schema_->required());
 }
 
 Primitive SqParamSchemaImpl::to_primitive() const {

--- a/src/system/templates/schema.gen.cpp.template
+++ b/src/system/templates/schema.gen.cpp.template
@@ -88,11 +88,12 @@
             ))
             for _, param_schema in ipairs(field_schema.params) do
                 table.insert(param_schema_values, string.format(
-                    "ParamSchema{%q, %s, %d, %d }",
+                    "ParamSchema{%q, %s, %d, %d, %s }",
                     param_schema.name,
                     doc_to_str(param_schema.doc),
                     param_schema.index,
-                    pt_index_by_name[param_schema.type]
+                    pt_index_by_name[param_schema.type],
+                    tostring(param_schema.required)
                 ))
             end
         end
@@ -160,6 +161,11 @@ std::size_t ParamSchema::index() const
 const PrimitiveTypeSchema& ParamSchema::type() const
 {
     return g_pts.at(type_index_);
+}
+
+bool ParamSchema::required() const
+{
+  return required_;
 }
 
 std::string_view FieldSchema::name() const

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,6 @@ add_test(
     NAME integration_tests
     COMMAND cmake -E env
         "SQ_BINARY=$<TARGET_FILE:sq>"
-        python3 -m pytest -p no:cacheprovider -v
+        python3 -m pytest -p no:cacheprovider -vv
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,28 @@
+# ------------------------------------------------------------------------------
+# Copyright 2021 Jonathan Haigh
+# SPDX-License-Identifier: MIT
+# ------------------------------------------------------------------------------
+
+import json
+import os
+import pathlib
+import pytest
+
+DEFAULT_SCHEMA = pathlib.Path(__file__).parent.parent / "src/system/schema.json"
+
+def pytest_addoption(parser):
+    parser.addoption("--schema", action="store", default=DEFAULT_SCHEMA)
+
+def pytest_generate_tests(metafunc):
+    # This is called for every test. Only get/set command line arguments
+    # if the argument is specified in the list of test "fixturenames".
+    schema_path = metafunc.config.option.schema
+    schema = None
+    with open(schema_path) as f:
+        schema = json.load(f)
+    if "sq_schema" in metafunc.fixturenames:
+        metafunc.parametrize("sq_schema", [schema])
+    if "sq_primitive_type" in metafunc.fixturenames:
+        metafunc.parametrize("sq_primitive_type", schema["primitive_types"])
+    if "sq_type" in metafunc.fixturenames:
+        metafunc.parametrize("sq_type", schema["types"])

--- a/test/test_sq_schema.py
+++ b/test/test_sq_schema.py
@@ -1,0 +1,49 @@
+# ------------------------------------------------------------------------------
+# Copyright 2021 Jonathan Haigh
+# SPDX-License-Identifier: MIT
+# ------------------------------------------------------------------------------
+
+import copy
+import pytest
+import util
+
+def flatten_doc_list(entity):
+    if isinstance(entity["doc"], list):
+        entity["doc"] = "\n".join(entity["doc"])
+
+def test_schema(sq_schema):
+    # We're going to test that the schema returned by SQ is (mostly) the same
+    # as the original schema in schema.json.
+    #
+    # There are a couple of things that will be different between the two
+    # schemas though:
+    # * doc arrays will have been converted to single strings with newlines.
+    # * SqParamSchema::default_value and SqParamSchema::default_value_doc are
+    #   not currently available when querying SQ.
+    # 
+    # Modify the schema we got from schema.json to match what we think SQ
+    # should return, then just do a test using "=="
+    schema = copy.deepcopy(sq_schema)
+    for t in schema["types"]:
+        flatten_doc_list(t)
+        for f in t["fields"]:
+            flatten_doc_list(f)
+            for p in f["params"]:
+                flatten_doc_list(p)
+                p.pop("default_value", None)
+                p.pop("default_value_doc", None)
+
+    result = util.sq(
+        "schema {"
+            "types {"
+                "name doc fields { "
+                    "name doc return_type return_list params {"
+                        "name doc index type required"
+                    "}"
+                "}"
+            "}"
+            " primitive_types { name doc }"
+            " root_type"
+        "}"
+    )
+    assert result == { "schema": schema }


### PR DESCRIPTION
The testing revealed that SqParamSchema's "required" field was missing,
so add that.

It also reminded me that SqParamSchema's "default_value" and
"default_value_doc" fields are optional but SQ doesn't have a way to
deal with optional fields so these are missing too.