### PR TITLE
Work around CMake issue causing tests to be ignored

### DIFF
--- a/src/parser/include/parser/Parser.h
+++ b/src/parser/include/parser/Parser.h
@@ -42,13 +42,13 @@ private:
   SQ_ND Ast *parse_dot_expression(Ast &parent);
   SQ_ND bool parse_field_call(Ast &parent);
   SQ_ND bool parse_parameter_pack(Ast &parent);
-  SQ_ND bool parse_parameter_list(Ast &parent);
-  SQ_ND bool parse_parameter(Ast &parent);
+  SQ_ND bool parse_parameter(Ast &parent, int &pos_count, int &named_count);
+  SQ_ND bool parse_positional_parameter(Ast &parent);
+  SQ_ND bool parse_named_parameter(Ast &parent);
   SQ_ND std::optional<Primitive> parse_primitive_value();
   SQ_ND std::optional<PrimitiveString> parse_dqstring();
   SQ_ND std::optional<PrimitiveBool> parse_bool();
   SQ_ND std::optional<PrimitiveFloat> parse_float();
-  SQ_ND bool parse_named_parameter(Ast &parent);
   SQ_ND bool parse_list_filter(Ast &parent);
   SQ_ND bool parse_slice_or_element_access(Ast &parent);
   SQ_ND bool parse_condition(Ast &parent);

--- a/src/results/test/test_results.cpp
+++ b/src/results/test/test_results.cpp
@@ -17,6 +17,7 @@
 
 #include <gsl/gsl>
 #include <gtest/gtest.h>
+#include <iostream>
 #include <range/v3/view/cartesian_product.hpp>
 #include <range/v3/view/iota.hpp>
 #include <range/v3/view/transform.hpp>
@@ -264,7 +265,16 @@ TEST_F(ResultTreeTest, TestGeneratedTreeWithMultipleCallsPerObject) {
 // Param passing tests
 // -----------------------------------------------------------------------------
 
-using ParamPassingTestCase = std::tuple<std::string_view, FieldCallParams>;
+struct ParamPassingTestCase {
+  const char *query_;
+  FieldCallParams fcp_;
+};
+
+std::ostream &operator<<(std::ostream &os, const ParamPassingTestCase &pptc) {
+  os << "(query=" << pptc.query_ << ",fcp=" << pptc.fcp_ << ")";
+  return os;
+}
+
 struct ResultTreeParamTest
     : MockFieldTest,
       ::testing::WithParamInterface<ParamPassingTestCase> {};


### PR DESCRIPTION
Fixes #62: Some parser tests are being ignored

There's a CMake bug
(https://gitlab.kitware.com/cmake/cmake/-/issues/21027)
that causes GoogleTest tests to be ignored under certain circumstances
when either:
* A test name is very long or one of the parameters for the test has
  a very long string representation.
* A test name or a parameter contains unbalanced pairs of brackets
  ('[' and ']').

Work around the first condition by telling GoogleTest how to print the
parameters to the tests so that it doesn't use an overly verbose string
representation of their bytes.

Work around the second condition by removing a couple of tests that
contained unbalanced brackets.

After fixing these issues one of the tests that was previously ignored
found an issue in the query parser where positional parameters were
being allowed to follow named parameters. Fix the parser to disallow
that.