### PR TITLE
Print exception type names on errors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
   try {
     return run_sq(argc, argv);
   } catch (const std::exception &e) {
-    std::cerr << e.what() << std::endl;
+    std::cerr << sq::util::base_type_name(e) << ": " << e.what() << std::endl;
     return 1;
   }
 }

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(sq_util
     "${SQ_UTIL_SRC_DIR}/strutil.cpp"
 
     "${SQ_UTIL_INCLUDE_DIR}/util/typeutil.h"
+    "${SQ_UTIL_INCLUDE_DIR}/util/typeutil.inl.h"
     "${SQ_UTIL_SRC_DIR}/typeutil.cpp"
 )
 target_include_directories(sq_util PUBLIC "${SQ_UTIL_INCLUDE_DIR}")

--- a/src/util/include/util/typeutil.h
+++ b/src/util/include/util/typeutil.h
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <gsl/gsl>
 #include <range/v3/range/concepts.hpp>
+#include <string>
 #include <type_traits>
 #include <variant>
 
@@ -101,7 +102,7 @@ concept SlowSizedRange =
  *
  * Throws if the value can't be represented by a gsl::index.
  */
-inline constexpr gsl::index to_index(std::integral auto v) {
+SQ_ND inline constexpr gsl::index to_index(std::integral auto v) {
   return gsl::narrow<gsl::index>(v);
 }
 
@@ -110,9 +111,16 @@ inline constexpr gsl::index to_index(std::integral auto v) {
  *
  * Throws if the value can't be represented by a std::size_t.
  */
-inline constexpr std::size_t to_size(std::integral auto v) {
+SQ_ND inline constexpr std::size_t to_size(std::integral auto v) {
   return gsl::narrow<std::size_t>(v);
 }
+
+/**
+ * Get the name of the "base type" of the given expression.
+ *
+ * The "base type" is the type with no references or cv qualification.
+ */
+SQ_ND std::string base_type_name(const auto &thing);
 
 } // namespace sq::util
 
@@ -128,5 +136,7 @@ inline constexpr bool enable_view<gsl::span<T, gsl::dynamic_extent>> = true;
 template <typename T> inline constexpr bool enable_view<gsl::span<T, 0>> = true;
 
 } // namespace ranges
+
+#include "util/typeutil.inl.h"
 
 #endif // SQ_INCLUDE_GUARD_util_typeutil_h_

--- a/src/util/include/util/typeutil.inl.h
+++ b/src/util/include/util/typeutil.inl.h
@@ -1,0 +1,25 @@
+/* -----------------------------------------------------------------------------
+ * Copyright 2021 Jonathan Haigh
+ * SPDX-License-Identifier: MIT
+ * ---------------------------------------------------------------------------*/
+
+#ifndef SQ_INCLUDE_GUARD_util_typeutil_inl_h_
+#define SQ_INCLUDE_GUARD_util_typeutil_inl_h_
+
+#include <typeinfo>
+
+namespace sq::util {
+
+namespace detail {
+
+SQ_ND std::string demangle(const char *type_name);
+
+} // namespace detail
+
+SQ_ND std::string base_type_name(const auto &thing) {
+  return detail::demangle(typeid(thing).name());
+}
+
+} // namespace sq::util
+
+#endif // SQ_INCLUDE_GUARD_util_typeutil_inl_h_

--- a/src/util/src/typeutil.cpp
+++ b/src/util/src/typeutil.cpp
@@ -4,3 +4,26 @@
  * ---------------------------------------------------------------------------*/
 
 #include "util/typeutil.h"
+
+#include <memory>
+#include <string>
+
+#if defined(__GNUC__) || defined(__clang__)
+#include <cxxabi.h>
+#define SQ_DEMANGLE
+#endif
+
+namespace sq::util::detail {
+
+#ifdef SQ_DEMANGLE
+std::string demangle(const char *type_name) {
+  auto status = int{-1}; // arbitrary non-zero initialization
+  const auto demangled = std::unique_ptr<char, void (*)(void *)>{
+      abi::__cxa_demangle(type_name, nullptr, nullptr, &status), std::free};
+  return (status == 0) ? demangled.get() : type_name;
+}
+#else
+std::string demangle(const char *type_name) { return type_name; }
+#endif
+
+} // namespace sq::util::detail

--- a/test/util/__init__.py
+++ b/test/util/__init__.py
@@ -110,7 +110,7 @@ def sq_error(query, pattern=None, flags=re.I):
     log(f"SQ stderr: {e.value.stderr}")
     log(f"SQ stdout: {e.value.stdout}")
     if pattern:
-        assert re.match(pattern, e.value.stderr, flags)
+        assert re.search(pattern, e.value.stderr, flags)
 
 
 def quote(string):


### PR DESCRIPTION
Sometimes std::exception::what doesn't give much information so print
the name of the type of the exception too.

Having done that, some tests started failing because they were only
matching patterns at the beginning of SQ's output rather than at any
point in the output. Fix that.