### PR TITLE
Add tests for SqDataSize fields

### DIFF
--- a/src/system/include/system/standard/SqDataSizeImpl.h
+++ b/src/system/include/system/standard/SqDataSizeImpl.h
@@ -15,7 +15,7 @@ namespace sq::system::standard {
 
 class SqDataSizeImpl : public SqDataSize<SqDataSizeImpl> {
 public:
-  explicit SqDataSizeImpl(std::size_t value);
+  explicit SqDataSizeImpl(PrimitiveInt value);
 
   SQ_ND Result get_B() const;
   SQ_ND Result get_KiB() const;
@@ -33,7 +33,7 @@ public:
   SQ_ND Primitive to_primitive() const override;
 
 private:
-  std::size_t value_;
+  PrimitiveInt value_;
 };
 
 } // namespace sq::system::standard

--- a/src/system/include/system/standard/SqRootImpl.h
+++ b/src/system/include/system/standard/SqRootImpl.h
@@ -21,6 +21,7 @@ public:
   SQ_ND static Result get_bool(PrimitiveBool value);
   SQ_ND static Result get_float(PrimitiveFloat value);
   SQ_ND static Result get_string(const PrimitiveString &value);
+  SQ_ND static Result get_data_size(PrimitiveInt bytes);
   SQ_ND Primitive to_primitive() const override;
 };
 

--- a/src/system/schema.json
+++ b/src/system/schema.json
@@ -416,7 +416,7 @@
                     "params": [
                         {
                             "index": 0,
-                            "name": "path",
+                            "name": "value",
                             "doc": "the path to get",
                             "type": "PrimitiveString",
                             "required": false,
@@ -520,6 +520,22 @@
                             "type": "PrimitiveString",
                             "required": false,
                             "default_value": ""
+                        }
+                    ]
+                },
+                {
+                    "name": "data_size",
+                    "doc": "Get an SqDataSize system object",
+                    "return_type": "SqDataSize",
+                    "return_list": false,
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "bytes",
+                            "doc": "the size in bytes of the data",
+                            "type": "PrimitiveInt",
+                            "required": false,
+                            "default_value": 0
                         }
                     ]
                 }

--- a/src/system/src/standard/SqDataSizeImpl.cpp
+++ b/src/system/src/standard/SqDataSizeImpl.cpp
@@ -5,6 +5,7 @@
 
 #include "system/standard/SqDataSizeImpl.h"
 
+#include "common_types/OutOfRangeError.h"
 #include "system/standard/SqFloatImpl.h"
 #include "system/standard/SqIntImpl.h"
 
@@ -30,17 +31,23 @@ inline constexpr Multiplier multiplier_Ti = multiplier_Gi * multiplier_Ki;
 inline constexpr Multiplier multiplier_Pi = multiplier_Ti * multiplier_Ki;
 inline constexpr Multiplier multiplier_Ei = multiplier_Pi * multiplier_Ki;
 
-Result size_in_units(std::size_t size, Multiplier multiplier) {
+Result size_in_units(PrimitiveInt size, Multiplier multiplier) {
   return std::make_shared<SqFloatImpl>(gsl::narrow<PrimitiveFloat>(size) /
                                        gsl::narrow<PrimitiveFloat>(multiplier));
 }
 
 } // namespace
 
-SqDataSizeImpl::SqDataSizeImpl(std::size_t value) : value_{value} {}
+SqDataSizeImpl::SqDataSizeImpl(PrimitiveInt value) : value_{value} {
+  if (value < 0) {
+    auto ss = std::ostringstream{};
+    ss << "Cannot create SqDataSize object with negative value " << value;
+    throw OutOfRangeError(ss.str());
+  }
+}
 
 Result SqDataSizeImpl::get_B() const {
-  return std::make_shared<SqIntImpl>(gsl::narrow<PrimitiveInt>(value_));
+  return std::make_shared<SqIntImpl>(value_);
 }
 
 Result SqDataSizeImpl::get_KiB() const {

--- a/src/system/src/standard/SqPathImpl.cpp
+++ b/src/system/src/standard/SqPathImpl.cpp
@@ -71,7 +71,7 @@ Result SqPathImpl::get_is_absolute() const {
 
 Result SqPathImpl::get_size() const {
   return std::make_shared<SqDataSizeImpl>(
-      gsl::narrow<std::size_t>(std::filesystem::file_size(value_)));
+      gsl::narrow<PrimitiveInt>(std::filesystem::file_size(value_)));
 }
 
 Primitive SqPathImpl::to_primitive() const { return value_.string(); }

--- a/src/system/src/standard/SqRootImpl.cpp
+++ b/src/system/src/standard/SqRootImpl.cpp
@@ -6,6 +6,7 @@
 #include "system/standard/SqRootImpl.h"
 
 #include "system/standard/SqBoolImpl.h"
+#include "system/standard/SqDataSizeImpl.h"
 #include "system/standard/SqFloatImpl.h"
 #include "system/standard/SqIntImpl.h"
 #include "system/standard/SqPathImpl.h"
@@ -58,6 +59,10 @@ Result SqRootImpl::get_float(PrimitiveFloat value) {
 
 Result SqRootImpl::get_string(const PrimitiveString &value) {
   return std::make_shared<SqStringImpl>(value);
+}
+
+Result SqRootImpl::get_data_size(PrimitiveInt bytes) {
+  return std::make_shared<SqDataSizeImpl>(bytes);
 }
 
 Primitive SqRootImpl::to_primitive() const { return PrimitiveString("ROOT"); }

--- a/test/test_sq_data_size.py
+++ b/test/test_sq_data_size.py
@@ -1,0 +1,33 @@
+# ------------------------------------------------------------------------------
+# Copyright 2021 Jonathan Haigh
+# SPDX-License-Identifier: MIT
+# ------------------------------------------------------------------------------
+
+import itertools
+import math
+import pytest
+import util
+
+DATA_SIZES = itertools.chain(
+    (0, 500, 512),
+    (int(1.5 * (1000 ** x)) for x in (1, 2, 3, 4, 5, 6)),
+    (int(2.5 * (1024 ** x)) for x in (1, 2, 3, 4, 5, 6)),
+)
+
+DECIMAL_UNITS = ("B", "kB", "MB", "GB", "TB", "PB", "EB")
+BINARY_UNITS = ("B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB")
+
+
+@pytest.mark.parametrize(
+    "exponent,unit,base,data_size",
+    (
+        (exponent, unit, base, data_size)
+        for data_size in DATA_SIZES
+        for base, units_tuple in ((1000, DECIMAL_UNITS), (1024, BINARY_UNITS))
+        for exponent, unit in enumerate(units_tuple)
+    )
+)
+def test_data_size_units(exponent, unit, base, data_size):
+    size_in_units = data_size / (base ** exponent)
+    result = util.sq(f"data_size({data_size}).{unit}")["data_size"][unit]
+    assert math.isclose(result, size_in_units)

--- a/test/test_sq_root.py
+++ b/test/test_sq_root.py
@@ -11,53 +11,102 @@ out_of_range_tests = []
 invalid_args_tests = []
 
 # SqRoot::int
-simple_tests.extend((f"int({i})",       { "int": int(i) }) for i in util.INT_STRS)
-simple_tests.extend((f"int(value={i})", { "int": int(i) }) for i in util.INT_STRS)
+simple_tests.extend((f"int({i})", {"int": int(i)}) for i in util.INT_STRS)
+simple_tests.extend(
+    (f"int(value={i})", {"int": int(i)}) for i in util.INT_STRS
+)
 out_of_range_tests.extend(f"int({i})" for i in util.OUT_OF_RANGE_INT_STRS)
-invalid_args_tests.extend(f"int({i})" for i in ("1.0", "true", "false", '"str"'))
+invalid_args_tests.extend(
+    f"int({i})" for i in ("1.0", "true", "false", '"str"')
+)
 
 # SqRoot::float
-simple_tests.extend((f"float({i})",       { "float": float(i) }) for i in util.FLOAT_STRS)
-simple_tests.extend((f"float(value={i})", { "float": float(i) }) for i in util.FLOAT_STRS)
-simple_tests.extend((f"float({i})",       { "float": float(i) }) for i in ("-1", "1", "0"))
+simple_tests.extend(
+    (f"float({i})", {"float": float(i)}) for i in util.FLOAT_STRS
+)
+simple_tests.extend(
+    (f"float(value={i})", {"float": float(i)}) for i in util.FLOAT_STRS
+)
+simple_tests.extend(
+    (f"float({i})", {"float": float(i)}) for i in ("-1", "1", "0")
+)
 out_of_range_tests.extend(f"float({i})" for i in util.OUT_OF_RANGE_FLOAT_STRS)
 invalid_args_tests.extend(f"float({i})" for i in ("true", "false", '"str"'))
 
 # SqRoot::bool
-simple_tests.append(("bool(true)",        { "bool": True }))
-simple_tests.append(("bool(false)",       { "bool": False }))
-simple_tests.append(("bool(value=true)",  { "bool": True }))
-simple_tests.append(("bool(value=false)", { "bool": False }))
-invalid_args_tests.extend(f"bool({i})" for i in ('"true"', '"false"', "1", "1.0" ))
+simple_tests.append(("bool(true)", {"bool": True}))
+simple_tests.append(("bool(false)", {"bool": False}))
+simple_tests.append(("bool(value=true)", {"bool": True}))
+simple_tests.append(("bool(value=false)", {"bool": False}))
+invalid_args_tests.extend(
+    f"bool({i})" for i in ('"true"', '"false"', "1", "1.0")
+)
 
 # SqRoot::string
-simple_tests.extend((f'string({util.quote(i)})',       { "string": i }) for i in util.STRINGS)
-simple_tests.extend((f'string(value={util.quote(i)})', { "string": i }) for i in util.STRINGS)
-invalid_args_tests.extend(f"string({i})" for i in ("-1" "1.0", "true", "false"))
+simple_tests.extend(
+    (f"string({util.quote(i)})", {"string": i}) for i in util.STRINGS
+)
+simple_tests.extend(
+    (f"string(value={util.quote(i)})", {"string": i}) for i in util.STRINGS
+)
+invalid_args_tests.extend(
+    f"string({i})" for i in ("-1" "1.0", "true", "false")
+)
 
 # SqRoot::ints
-simple_tests.extend([
-    ("ints(0, 5)",            { "ints": [ 0,  1,  2,  3,  4] }),
-    ("ints(-5, 0)",           { "ints": [-5, -4, -3, -2, -1] }),
-    ("ints(-6, -1)",          { "ints": [-6, -5, -4, -3, -2] }),
-    ("ints(5)[:5]",           { "ints": [ 5,  6,  7,  8,  9] }),
-    ("ints(-5)[:5]",          { "ints": [-5, -4, -3, -2, -1] }),
-    ("ints(start=5)[:5]",     { "ints": [ 5,  6,  7,  8,  9] }),
-    ("ints(stop=5)",          { "ints": [ 0,  1,  2,  3,  4] }),
-    ("ints(5, stop=10)",      { "ints": [ 5,  6,  7,  8,  9] }),
-    ("ints(start=5, stop=10)",{ "ints": [ 5,  6,  7,  8,  9] }),
-])
+simple_tests.extend(
+    [
+        ("ints(0, 5)", {"ints": [0, 1, 2, 3, 4]}),
+        ("ints(-5, 0)", {"ints": [-5, -4, -3, -2, -1]}),
+        ("ints(-6, -1)", {"ints": [-6, -5, -4, -3, -2]}),
+        ("ints(5)[:5]", {"ints": [5, 6, 7, 8, 9]}),
+        ("ints(-5)[:5]", {"ints": [-5, -4, -3, -2, -1]}),
+        ("ints(start=5)[:5]", {"ints": [5, 6, 7, 8, 9]}),
+        ("ints(stop=5)", {"ints": [0, 1, 2, 3, 4]}),
+        ("ints(5, stop=10)", {"ints": [5, 6, 7, 8, 9]}),
+        ("ints(start=5, stop=10)", {"ints": [5, 6, 7, 8, 9]}),
+    ]
+)
 
 # SqRoot::path
-simple_tests.extend((f'path({util.quote(i)})', { "path": i }) for i in util.PATH_STRS)
+simple_tests.extend(
+    (f"path({util.quote(i)})", {"path": i}) for i in util.PATH_STRS
+)
+simple_tests.extend(
+    (f"path(value={util.quote(i)})", {"path": i}) for i in util.PATH_STRS
+)
+
+# SqRoot::data_size
+simple_tests.extend(
+    (f"data_size({i})", {"data_size": int(i)})
+    for i in util.INT_STRS
+    if int(i) >= 0
+)
+
+simple_tests.extend(
+    (f"data_size(bytes={i})", {"data_size": int(i)})
+    for i in util.INT_STRS
+    if int(i) >= 0
+)
+
+out_of_range_tests.extend(
+    f"data_size({i})" for i in util.INT_STRS if int(i) < 0
+)
+
+out_of_range_tests.extend(
+    f"data_size({i})" for i in util.OUT_OF_RANGE_INT_STRS
+)
+
 
 @pytest.mark.parametrize("query,result", simple_tests)
 def test_simple(query, result):
     assert util.sq(query) == result
 
+
 @pytest.mark.parametrize("query", out_of_range_tests)
 def test_out_of_range(query):
     util.sq_error(query, "out ?of ?range")
+
 
 @pytest.mark.parametrize("query", invalid_args_tests)
 def test_invalid_argument(query):


### PR DESCRIPTION
Upon running the tests, the first thing to notice was that the error
message in the exception that SqDataSize's constructor throws if the
value is negative is terrible. Throw an OutOfRangeError rather than
relying on gsl::narrow to produce a good error message.

Make things easier by not converting between unsigned and signed types,
but instead just storing data sizes as PrimitiveInts (int64_ts) and
doing a "< 0" check in the constructor.