### PR TITLE
Add support for "null" results

### DIFF
--- a/src/common_types/include/common_types/Field.h
+++ b/src/common_types/include/common_types/Field.h
@@ -27,7 +27,7 @@ using FieldRange = ranges::any_view<FieldPtr, Cat>;
  * The result of accessing a field of a system object.
  */
 using Result = std::variant<
-    FieldPtr, FieldRange<ranges::category::input>,
+    PrimitiveNull, FieldPtr, FieldRange<ranges::category::input>,
     FieldRange<ranges::category::input | ranges::category::sized>,
     FieldRange<ranges::category::forward>,
     FieldRange<ranges::category::forward | ranges::category::sized>,

--- a/src/common_types/include/common_types/Primitive.fwd.h
+++ b/src/common_types/include/common_types/Primitive.fwd.h
@@ -16,9 +16,10 @@ using PrimitiveString = std::string;
 using PrimitiveInt = std::int64_t;
 using PrimitiveFloat = double;
 using PrimitiveBool = bool;
+struct PrimitiveNull;
 
-using Primitive =
-    std::variant<PrimitiveString, PrimitiveInt, PrimitiveFloat, PrimitiveBool>;
+using Primitive = std::variant<PrimitiveString, PrimitiveInt, PrimitiveFloat,
+                               PrimitiveBool, PrimitiveNull>;
 
 } // namespace sq
 

--- a/src/common_types/include/common_types/Primitive.h
+++ b/src/common_types/include/common_types/Primitive.h
@@ -33,6 +33,15 @@ SQ_ND std::string primitive_to_str(const PrimitiveAlternative auto &value);
 template <PrimitiveAlternative T>
 SQ_ND T convert_primitive(const Primitive &value);
 
+struct PrimitiveNull {
+  auto operator<=>(const PrimitiveNull &) const noexcept = default;
+  bool operator==(const PrimitiveNull &) const noexcept = default;
+};
+
+std::ostream &operator<<(std::ostream &os, const PrimitiveNull &pn);
+
+inline constexpr auto primitive_null = PrimitiveNull{};
+
 } // namespace sq
 
 #include "Primitive.inl.h"

--- a/src/common_types/include/common_types/Primitive.inl.h
+++ b/src/common_types/include/common_types/Primitive.inl.h
@@ -35,6 +35,10 @@ template <> struct PrimitiveTypeName<PrimitiveBool> {
   static constexpr std::string_view value = "PrimitiveBool";
 };
 
+template <> struct PrimitiveTypeName<PrimitiveNull> {
+  static constexpr std::string_view value = "PrimitiveNull";
+};
+
 namespace detail {
 
 struct PrimitiveToStrVisitor {

--- a/src/common_types/include/common_types/errors.h
+++ b/src/common_types/include/common_types/errors.h
@@ -10,6 +10,7 @@
 #include "common_types/Token.fwd.h"
 
 #include <cstddef>
+#include <filesystem>
 #include <gsl/gsl>
 #include <stdexcept>
 #include <string_view>
@@ -162,6 +163,23 @@ class PullupWithSiblingsError : public Exception {
  */
 class UdevError : public Exception {
   using Exception::Exception;
+};
+
+/**
+ * Error indicating that a filesystem error ocurred.
+ */
+class FilesystemError : public Exception {
+  using Exception::Exception;
+};
+
+/**
+ * Error indicating that a file does not exist.
+ */
+class FileNotFoundError : public FilesystemError {
+public:
+  using FilesystemError::FilesystemError;
+
+  FileNotFoundError(const std::filesystem::path &path);
 };
 
 } // namespace sq

--- a/src/common_types/src/Primitive.cpp
+++ b/src/common_types/src/Primitive.cpp
@@ -27,4 +27,9 @@ std::string primitive_to_str(const Primitive &value) {
   return std::visit(detail::PrimitiveToStrVisitor{}, value);
 }
 
+std::ostream &operator<<(std::ostream &os, SQ_MU const PrimitiveNull &pn) {
+  os << "null";
+  return os;
+}
+
 } // namespace sq

--- a/src/common_types/src/errors.cpp
+++ b/src/common_types/src/errors.cpp
@@ -68,4 +68,7 @@ ParseError::ParseError(const Token &token, const TokenKindSet &expecting)
           "parse error: unexpected {}; expecting one of: {}\n{}", token,
           fmt::join(expecting, ", "), show_pos_in_query(token))} {}
 
+FileNotFoundError::FileNotFoundError(const std::filesystem::path &path)
+    : FilesystemError{fmt::format("file \"{}\" not found", path)} {}
+
 } // namespace sq

--- a/src/common_types/test/Primitive_test_util.cpp
+++ b/src/common_types/test/Primitive_test_util.cpp
@@ -15,5 +15,6 @@ Primitive to_primitive(PrimitiveInt v) { return v; }
 Primitive to_primitive(int v) { return PrimitiveInt{v}; }
 Primitive to_primitive(PrimitiveFloat v) { return v; }
 Primitive to_primitive(PrimitiveBool v) { return v; }
+Primitive to_primitive(PrimitiveNull v) { return v; }
 
 } // namespace sq::test

--- a/src/common_types/test/include/test/Primitive_test_util.h
+++ b/src/common_types/test/include/test/Primitive_test_util.h
@@ -22,6 +22,7 @@ SQ_ND Primitive to_primitive(PrimitiveInt v);
 SQ_ND Primitive to_primitive(int v);
 SQ_ND Primitive to_primitive(PrimitiveFloat v);
 SQ_ND Primitive to_primitive(PrimitiveBool v);
+SQ_ND Primitive to_primitive(PrimitiveNull v);
 
 } // namespace sq::test
 

--- a/src/common_types/test/test_common_types.cpp
+++ b/src/common_types/test/test_common_types.cpp
@@ -28,6 +28,7 @@ TEST(CommonTypesTest, TestPrimitive) {
   test_primitive_type<PrimitiveInt>();
   test_primitive_type<PrimitiveFloat>();
   test_primitive_type<PrimitiveBool>();
+  test_primitive_type<PrimitiveNull>();
 }
 
 TEST(CommonTypesTest, TestPrimitiveToStr) {
@@ -42,6 +43,7 @@ TEST(CommonTypesTest, TestPrimitiveToStr) {
   EXPECT_EQ(primitive_to_str(Primitive{PrimitiveFloat{-1.1}}), "-1.1");
   EXPECT_EQ(primitive_to_str(Primitive{PrimitiveBool{true}}), "true");
   EXPECT_EQ(primitive_to_str(Primitive{PrimitiveBool{false}}), "false");
+  EXPECT_EQ(primitive_to_str(Primitive{primitive_null}), "null");
 }
 
 class FieldCallParamsTest : public testing::Test {

--- a/src/parser/include/parser/Parser.h
+++ b/src/parser/include/parser/Parser.h
@@ -34,6 +34,11 @@ public:
    */
   SQ_ND Ast parse();
 
+  /**
+   * Parse the input query as a Primitive.
+   */
+  SQ_ND Primitive parse_primitive();
+
 private:
   SQ_ND bool parse_query(Ast &parent);
   SQ_ND bool parse_field_tree_list(Ast &parent);

--- a/src/parser/src/Parser.cpp
+++ b/src/parser/src/Parser.cpp
@@ -26,6 +26,14 @@ Ast Parser::parse() {
   return ast;
 }
 
+Primitive Parser::parse_primitive() {
+  auto opt_prim = parse_primitive_value();
+  if (!opt_prim) {
+    throw ParseError{tokens_.read(), expecting_};
+  }
+  return opt_prim.value();
+}
+
 // query: field_tree_list Eof
 bool Parser::parse_query(Ast &parent) {
   if (!parse_field_tree_list(parent)) {

--- a/src/results/src/Filter.cpp
+++ b/src/results/src/Filter.cpp
@@ -58,6 +58,10 @@ template <> struct FilterImpl<parser::ElementAccessSpec> : Filter {
     throw NotAnArrayError{"Cannot apply array filter to non-array field"};
   }
 
+  SQ_ND Result operator()(SQ_MU const PrimitiveNull &pn) const {
+    throw NotAnArrayError{"Cannot apply array filter to null field"};
+  }
+
   SQ_ND Result operator()(ranges::cpp20::view auto &&rng) const {
     if (index_ >= 0) {
       return nonnegative_index_access(SQ_FWD(rng), index_);
@@ -115,6 +119,10 @@ template <> struct FilterImpl<parser::SliceSpec> : Filter {
 
   SQ_ND Result operator()(SQ_MU const FieldPtr &fp) const {
     throw NotAnArrayError{"Cannot apply array filter to non-array field"};
+  }
+
+  SQ_ND Result operator()(SQ_MU const PrimitiveNull &pn) const {
+    throw NotAnArrayError{"Cannot apply array filter to null field"};
   }
 
   SQ_ND Result operator()(ranges::cpp20::view auto &&rng) const {
@@ -309,6 +317,10 @@ template <> struct FilterImpl<parser::ComparisonSpec> : Filter {
 
   SQ_ND Result operator()(SQ_MU const FieldPtr &field) const {
     throw NotAnArrayError{"Cannot apply array filter to non-array field"};
+  }
+
+  SQ_ND Result operator()(SQ_MU const PrimitiveNull &pn) const {
+    throw NotAnArrayError{"Cannot apply array filter to null field"};
   }
 
   SQ_ND Result operator()(ranges::cpp20::view auto &&rng) const {

--- a/src/results/src/results.cpp
+++ b/src/results/src/results.cpp
@@ -27,12 +27,17 @@ class ResultToDataVisitor {
 public:
   explicit ResultToDataVisitor(const parser::Ast &ast) : ast_{&ast} {}
 
+  SQ_ND Data operator()(PrimitiveNull &&null) const;
   SQ_ND Data operator()(FieldPtr &&field) const;
   SQ_ND Data operator()(ranges::cpp20::view auto &&rng) const;
 
 private:
   gsl::not_null<const parser::Ast *> ast_;
 };
+
+Data ResultToDataVisitor::operator()(PrimitiveNull &&null) const {
+  return null;
+}
 
 Data ResultToDataVisitor::operator()(FieldPtr &&field) const {
   if (ast_->children().empty()) {

--- a/src/serialization/src/serialize.cpp
+++ b/src/serialization/src/serialize.cpp
@@ -31,12 +31,10 @@ public:
                     true /* copy */
     );
   }
-
   void operator()(const PrimitiveInt &i) { writer_->Int64(i); }
-
   void operator()(const PrimitiveBool &b) { writer_->Bool(b); }
-
   void operator()(const PrimitiveFloat &f) { writer_->Double(f); }
+  void operator()(SQ_MU const PrimitiveNull &pn) { writer_->Null(); }
 
 private:
   gsl::not_null<Writer *> writer_;

--- a/src/system/include/system/linux/SqAnyPrimitiveImpl.h
+++ b/src/system/include/system/linux/SqAnyPrimitiveImpl.h
@@ -1,0 +1,26 @@
+/* -----------------------------------------------------------------------------
+ * Copyright 2021 Jonathan Haigh
+ * SPDX-License-Identifier: MIT
+ * ---------------------------------------------------------------------------*/
+
+#ifndef SQ_INCLUDE_GUARD_system_linux_SqAnyPrimitiveImpl_h_
+#define SQ_INCLUDE_GUARD_system_linux_SqAnyPrimitiveImpl_h_
+
+#include "system/SqAnyPrimitive.gen.h"
+#include "util/typeutil.h"
+
+namespace sq::system::linux {
+
+class SqAnyPrimitiveImpl : public SqAnyPrimitive<SqAnyPrimitiveImpl> {
+public:
+  explicit SqAnyPrimitiveImpl(const Primitive &prim);
+
+  SQ_ND Primitive to_primitive() const override;
+
+private:
+  Primitive prim_;
+};
+
+} // namespace sq::system::linux
+
+#endif // SQ_INCLUDE_GUARD_system_linux_SqAnyPrimitiveImpl_h_

--- a/src/system/include/system/linux/SqFieldSchemaImpl.h
+++ b/src/system/include/system/linux/SqFieldSchemaImpl.h
@@ -23,6 +23,7 @@ public:
   SQ_ND Result get_params() const;
   SQ_ND Result get_return_type() const;
   SQ_ND Result get_return_list() const;
+  SQ_ND Result get_null() const;
 
   SQ_ND Primitive to_primitive() const override;
 

--- a/src/system/include/system/linux/SqParamSchemaImpl.h
+++ b/src/system/include/system/linux/SqParamSchemaImpl.h
@@ -23,6 +23,8 @@ public:
   SQ_ND Result get_index() const;
   SQ_ND Result get_type() const;
   SQ_ND Result get_required() const;
+  SQ_ND Result get_default_value() const;
+  SQ_ND Result get_default_value_doc() const;
 
   SQ_ND Primitive to_primitive() const override;
 

--- a/src/system/include/system/schema.h
+++ b/src/system/include/system/schema.h
@@ -6,10 +6,12 @@
 #ifndef SQ_INCLUDE_GUARD_system_schema_h_
 #define SQ_INCLUDE_GUARD_system_schema_h_
 
+#include "common_types/Primitive.h"
 #include "util/typeutil.h"
 
 #include <cstddef>
 #include <gsl/gsl>
+#include <optional>
 #include <string_view>
 
 namespace sq::system {
@@ -40,15 +42,19 @@ class ParamSchema {
 public:
   constexpr ParamSchema(std::string_view name, std::string_view doc,
                         std::size_t index, std::size_t type_index,
-                        bool required)
-      : name_{name}, doc_{doc}, index_{index},
-        type_index_{type_index}, required_{required} {}
+                        bool required, std::string_view default_value_str,
+                        std::string_view default_value_doc)
+      : name_{name}, doc_{doc}, index_{index}, type_index_{type_index},
+        required_{required}, default_value_str_{default_value_str},
+        default_value_doc_{default_value_doc} {}
 
   SQ_ND std::string_view name() const;
   SQ_ND std::string_view doc() const;
   SQ_ND std::size_t index() const;
   SQ_ND const PrimitiveTypeSchema &type() const;
   SQ_ND bool required() const;
+  SQ_ND std::optional<Primitive> default_value() const;
+  SQ_ND std::string_view default_value_doc() const;
 
 private:
   std::string_view name_;
@@ -56,6 +62,8 @@ private:
   std::size_t index_;
   std::size_t type_index_;
   bool required_;
+  std::string_view default_value_str_;
+  std::string_view default_value_doc_;
 };
 
 class TypeSchema;
@@ -68,16 +76,19 @@ public:
   constexpr FieldSchema(std::string_view name, std::string_view doc,
                         std::size_t params_begin_index,
                         std::size_t params_end_index,
-                        std::size_t return_type_index, bool return_list)
+                        std::size_t return_type_index, bool return_list,
+                        bool null)
       : name_{name}, doc_{doc}, params_begin_index_{params_begin_index},
         params_end_index_{params_end_index},
-        return_type_index_{return_type_index}, return_list_{return_list} {}
+        return_type_index_{return_type_index},
+        return_list_{return_list}, null_{null} {}
 
   SQ_ND std::string_view name() const;
   SQ_ND std::string_view doc() const;
   SQ_ND gsl::span<const ParamSchema> params() const;
   SQ_ND const TypeSchema &return_type() const;
   SQ_ND bool return_list() const;
+  SQ_ND bool null() const;
 
 private:
   std::string_view name_;
@@ -86,6 +97,7 @@ private:
   std::size_t params_end_index_;
   std::size_t return_type_index_;
   bool return_list_;
+  bool null_;
 };
 
 /**

--- a/src/system/schema.json
+++ b/src/system/schema.json
@@ -20,6 +20,11 @@
     "root_type": "SqRoot",
     "types": [
         {
+            "name": "SqAnyPrimitive",
+            "doc": "A primitive value of unspecified type",
+            "fields": []
+        },
+        {
             "name": "SqBool",
             "doc": "A boolean type",
             "fields": []
@@ -33,6 +38,7 @@
                     "doc": "Size of the data in bytes",
                     "return_type": "SqInt",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -40,6 +46,7 @@
                     "doc": "Size of the data in kibibytes (1KiB = 1024 bytes)",
                     "return_type": "SqFloat",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -47,6 +54,7 @@
                     "doc": "Size of the data in kilobytes (1kB = 1000 bytes)",
                     "return_type": "SqFloat",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -54,6 +62,7 @@
                     "doc": "Size of the data in mebibytes (1MiB = 1024\\ :sup:`2` bytes)",
                     "return_type": "SqFloat",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -61,6 +70,7 @@
                     "doc": "Size of the data in megabytes (1MB = 1000 \\ :sup:`2` bytes)",
                     "return_type": "SqFloat",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -68,6 +78,7 @@
                     "doc": "Size of the data in gibibytes (1GiB = 1024\\ :sup:`3` bytes)",
                     "return_type": "SqFloat",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -75,6 +86,7 @@
                     "doc": "Size of the data in gigabytes (1GB = 1000\\ :sup:`3` bytes)",
                     "return_type": "SqFloat",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -82,6 +94,7 @@
                     "doc": "Size of the data in tebibytes (1TiB = 1024\\ :sup:`4` bytes)",
                     "return_type": "SqFloat",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -89,6 +102,7 @@
                     "doc": "Size of the data in terabytes (1TB = 1000\\ :sup:`4` bytes)",
                     "return_type": "SqFloat",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -96,6 +110,7 @@
                     "doc": "Size of the data in pebibytes (1PiB = 1024\\ :sup:`5` bytes)",
                     "return_type": "SqFloat",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -103,6 +118,7 @@
                     "doc": "Size of the data in petabytes (1PB = 1000\\ :sup:`5` bytes)",
                     "return_type": "SqFloat",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -110,6 +126,7 @@
                     "doc": "Size of the data in exbibytes (1EiB = 1024\\ :sup:`6` bytes)",
                     "return_type": "SqFloat",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -117,6 +134,7 @@
                     "doc": "Size of the data in exabytes (1EB = 1000\\ :sup:`6` bytes)",
                     "return_type": "SqFloat",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 }
             ]
@@ -130,6 +148,7 @@
                     "doc": "The path for the device in /sys",
                     "return_type": "SqPath",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -137,6 +156,7 @@
                     "doc": "The name of the device",
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -144,6 +164,7 @@
                     "doc": "The subsystem to which the device belongs",
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": true,
                     "params": []
                 },
                 {
@@ -151,6 +172,7 @@
                     "doc": "The node for the device in /dev",
                     "return_type": "SqPath",
                     "return_list": false,
+                    "null": true,
                     "params": []
                 }
             ]
@@ -164,6 +186,7 @@
                     "doc": "The name of the field",
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -171,6 +194,7 @@
                     "doc": "The documentation for the field",
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -178,6 +202,7 @@
                     "doc": "The field's parameters",
                     "return_type": "SqParamSchema",
                     "return_list": true,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -185,6 +210,7 @@
                     "doc": "The fields return type",
                     "return_type": "SqTypeSchema",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -192,6 +218,15 @@
                     "doc": "Whether the field returns multiple values or not",
                     "return_type": "SqBool",
                     "return_list": false,
+                    "null": false,
+                    "params": []
+                },
+                {
+                    "name": "null",
+                    "doc": "Whether the field can return null values or not",
+                    "return_type": "SqBool",
+                    "return_list": false,
+                    "null": false,
                     "params": []
                 }
             ]
@@ -216,6 +251,7 @@
                     "doc": "The name of the parameter",
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -223,6 +259,7 @@
                     "doc": "The documentation for the parameter",
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -233,6 +270,7 @@
                     ],
                     "return_type": "SqInt",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -243,6 +281,7 @@
                     ],
                     "return_type": "SqPrimitiveTypeSchema",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -250,6 +289,23 @@
                     "doc": "Whether the parameter is required or not",
                     "return_type": "SqBool",
                     "return_list": false,
+                    "null": false,
+                    "params": []
+                },
+                {
+                    "name": "default_value",
+                    "doc": "A default value for the parameter",
+                    "return_type": "SqAnyPrimitive",
+                    "return_list": false,
+                    "null": true,
+                    "params": []
+                },
+                {
+                    "name": "default_value_doc",
+                    "doc": "The documentation for the parameter's default value",
+                    "return_type": "SqString",
+                    "return_list": false,
+                    "null": true,
                     "params": []
                 }
             ]
@@ -263,6 +319,7 @@
                     "doc": "Get the path as an SqString",
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -280,6 +337,7 @@
                     ],
                     "return_type": "SqPath",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -297,6 +355,7 @@
                     ],
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -315,6 +374,7 @@
                     ],
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -336,6 +396,7 @@
                     ],
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -347,6 +408,7 @@
                     ],
                     "return_type": "SqPath",
                     "return_list": true,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -359,6 +421,7 @@
                     ],
                     "return_type": "SqString",
                     "return_list": true,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -374,6 +437,7 @@
                     ],
                     "return_type": "SqPath",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -389,6 +453,7 @@
                     ],
                     "return_type": "SqPath",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -396,6 +461,7 @@
                     "doc": "Get whether the path is absolute",
                     "return_type": "SqBool",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -403,6 +469,7 @@
                     "doc": "Get the size of the file referred to by the path",
                     "return_type": "SqDataSize",
                     "return_list": false,
+                    "null": true,
                     "params": []
                 }
             ]
@@ -416,6 +483,7 @@
                     "doc": "The name of the primitive type",
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -423,6 +491,7 @@
                     "doc": "The documentation for the primitive type",
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 }
             ]
@@ -440,6 +509,7 @@
                     "doc": "Get the system schema",
                     "return_type": "SqSchema",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -447,6 +517,7 @@
                     "doc": "Get an SqPath system object",
                     "return_type":  "SqPath",
                     "return_list": false,
+                    "null": false,
                     "params": [
                         {
                             "index": 0,
@@ -464,6 +535,7 @@
                     "doc": "Get an SqInt system object",
                     "return_type": "SqInt",
                     "return_list": false,
+                    "null": false,
                     "params": [
                         {
                             "index": 0,
@@ -489,6 +561,7 @@
                     ],
                     "return_type": "SqInt",
                     "return_list": true,
+                    "null": false,
                     "params": [
                         {
                             "index": 0,
@@ -514,6 +587,7 @@
                     "doc": "Get an SqBool system object",
                     "return_type": "SqBool",
                     "return_list": false,
+                    "null": false,
                     "params": [
                         {
                             "index": 0,
@@ -530,6 +604,7 @@
                     "doc": "Get an SqFloat system object",
                     "return_type": "SqFloat",
                     "return_list": false,
+                    "null": false,
                     "params": [
                         {
                             "index": 0,
@@ -546,6 +621,7 @@
                     "doc": "Get an SqString system object",
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": false,
                     "params": [
                         {
                             "index": 0,
@@ -562,6 +638,7 @@
                     "doc": "Get an SqDataSize system object",
                     "return_type": "SqDataSize",
                     "return_list": false,
+                    "null": false,
                     "params": [
                         {
                             "index": 0,
@@ -578,6 +655,7 @@
                     "doc": "Get a list of devices in the system",
                     "return_type": "SqDevice",
                     "return_list": true,
+                    "null": false,
                     "params": []
                 }
             ]
@@ -591,6 +669,7 @@
                     "doc": "The SQ root type",
                     "return_type": "SqTypeSchema",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -598,6 +677,7 @@
                     "doc": "a list of the SQ primitive types",
                     "return_type": "SqPrimitiveTypeSchema",
                     "return_list": true,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -605,6 +685,7 @@
                     "doc": "a list of the SQ system object types",
                     "return_type": "SqTypeSchema",
                     "return_list": true,
+                    "null": false,
                     "params": []
                 }
             ]
@@ -623,6 +704,7 @@
                     "doc": "The name of the type",
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -630,6 +712,7 @@
                     "doc": "The documentation for the SQ system object type",
                     "return_type": "SqString",
                     "return_list": false,
+                    "null": false,
                     "params": []
                 },
                 {
@@ -637,6 +720,7 @@
                     "doc": "a list of the type's fields",
                     "return_type": "SqFieldSchema",
                     "return_list": true,
+                    "null": false,
                     "params": []
                 }
             ]

--- a/src/system/sq_functions.cmake
+++ b/src/system/sq_functions.cmake
@@ -5,6 +5,7 @@
 
 function(sq_expand_for_each_type FORMAT_STRING OUTPUT_VAR)
     set(SQ_TYPES
+        SqAnyPrimitive
         SqBool
         SqDataSize
         SqDevice

--- a/src/system/sq_system_schema.cmake
+++ b/src/system/sq_system_schema.cmake
@@ -20,6 +20,8 @@ add_library(sq_system_schema
 set_target_properties(sq_system_schema PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(sq_system_schema PUBLIC ${SQ_SYSTEM_SCHEMA_INCLUDE_DIR})
 target_link_libraries(sq_system_schema PUBLIC sq_util)
+target_link_libraries(sq_system_schema PUBLIC sq_common_types)
+target_link_libraries(sq_system_schema PUBLIC sq_parser)
 target_link_libraries(sq_system_schema PUBLIC gsl)
 
 # Clang-Tidy complains about magic numbers in the generated schema.gen.cpp

--- a/src/system/src/CacheingField.cpp
+++ b/src/system/src/CacheingField.cpp
@@ -16,6 +16,7 @@ struct ShouldCache {
     return std::visit(*this, value);
   }
 
+  SQ_ND bool operator()(SQ_MU const PrimitiveNull &value) const { return true; }
   SQ_ND bool operator()(SQ_MU const FieldPtr &value) const { return true; }
 
   SQ_ND bool operator()(SQ_MU const ranges::cpp20::range auto &rng) const {

--- a/src/system/src/linux/SqAnyPrimitiveImpl.cpp
+++ b/src/system/src/linux/SqAnyPrimitiveImpl.cpp
@@ -1,0 +1,13 @@
+/* -----------------------------------------------------------------------------
+ * Copyright 2021 Jonathan Haigh
+ * SPDX-License-Identifier: MIT
+ * ---------------------------------------------------------------------------*/
+
+#include "system/linux/SqAnyPrimitiveImpl.h"
+
+namespace sq::system::linux {
+
+SqAnyPrimitiveImpl::SqAnyPrimitiveImpl(const Primitive &prim) : prim_{prim} {}
+Primitive SqAnyPrimitiveImpl::to_primitive() const { return prim_; }
+
+} // namespace sq::system::linux

--- a/src/system/src/linux/SqDeviceImpl.cpp
+++ b/src/system/src/linux/SqDeviceImpl.cpp
@@ -21,12 +21,20 @@ Result SqDeviceImpl::get_sys_name() const {
 
 Result SqDeviceImpl::get_subsystem() const {
   Expects(dev_ != nullptr);
-  return std::make_shared<SqStringImpl>(dev_->subsystem());
+  auto subsystem = dev_->subsystem();
+  if (subsystem.empty()) {
+    return primitive_null;
+  }
+  return std::make_shared<SqStringImpl>(std::move(subsystem));
 }
 
 Result SqDeviceImpl::get_dev_node() const {
   Expects(dev_ != nullptr);
-  return std::make_shared<SqPathImpl>(dev_->dev_node());
+  auto devnode = dev_->dev_node();
+  if (devnode.empty()) {
+    return primitive_null;
+  }
+  return std::make_shared<SqPathImpl>(std::move(devnode));
 }
 
 Primitive SqDeviceImpl::to_primitive() const {

--- a/src/system/src/linux/SqFieldSchemaImpl.cpp
+++ b/src/system/src/linux/SqFieldSchemaImpl.cpp
@@ -43,6 +43,10 @@ Result SqFieldSchemaImpl::get_return_list() const {
   return std::make_shared<SqBoolImpl>(field_schema_->return_list());
 }
 
+Result SqFieldSchemaImpl::get_null() const {
+  return std::make_shared<SqBoolImpl>(field_schema_->null());
+}
+
 Primitive SqFieldSchemaImpl::to_primitive() const {
   return PrimitiveString{field_schema_->name()};
 }

--- a/src/system/src/linux/SqParamSchemaImpl.cpp
+++ b/src/system/src/linux/SqParamSchemaImpl.cpp
@@ -5,6 +5,7 @@
 
 #include "system/linux/SqParamSchemaImpl.h"
 
+#include "system/linux/SqAnyPrimitiveImpl.h"
 #include "system/linux/SqBoolImpl.h"
 #include "system/linux/SqIntImpl.h"
 #include "system/linux/SqPrimitiveTypeSchemaImpl.h"
@@ -35,6 +36,22 @@ Result SqParamSchemaImpl::get_type() const {
 
 Result SqParamSchemaImpl::get_required() const {
   return std::make_shared<SqBoolImpl>(param_schema_->required());
+}
+
+Result SqParamSchemaImpl::get_default_value() const {
+  auto opt_prim = param_schema_->default_value();
+  if (opt_prim) {
+    return std::make_shared<SqAnyPrimitiveImpl>(opt_prim.value());
+  }
+  return primitive_null;
+}
+
+Result SqParamSchemaImpl::get_default_value_doc() const {
+  auto doc = param_schema_->default_value_doc();
+  if (doc.data() != nullptr) {
+    return std::make_shared<SqStringImpl>(doc);
+  }
+  return primitive_null;
 }
 
 Primitive SqParamSchemaImpl::to_primitive() const {

--- a/src/system/templates/schema.gen.cpp.template
+++ b/src/system/templates/schema.gen.cpp.template
@@ -61,8 +61,23 @@
     local noof_pts = pt_index
 
     function doc_to_str(doc)
+        if doc == nil then
+            return "std::string_view{}"
+        end
         local str = (type(doc) == "table") and table.concat(doc, "\n") or doc
         return string.format("R\"*DOC*STRING*(%s)*DOC*STRING*\"", str)
+    end
+
+    function primitive_to_str(value, typ)
+        if value == nil then
+            return ""
+        end
+        if typ == "PrimitiveString" then
+            value = value:gsub("\\", "\\\\")
+            value = value:gsub("\"", "\\\"")
+            return string.format("\"%s\"", value)
+        end
+        return tostring(value)
     end
 
     local type_schema_values = {}
@@ -78,22 +93,25 @@
         ))
         for _, field_schema in ipairs(type_schema.fields) do
             table.insert(field_schema_values, string.format(
-                "FieldSchema{%q, %s, %d, %d, %d, %s}",
+                "FieldSchema{%q, %s, %d, %d, %d, %s, %s}",
                 field_schema.name,
                 doc_to_str(field_schema.doc),
                 field_schema.params_begin_index,
                 field_schema.params_end_index,
                 type_index_by_name[field_schema.return_type],
-                tostring(field_schema.return_list)
+                tostring(field_schema.return_list),
+                tostring(field_schema.null)
             ))
             for _, param_schema in ipairs(field_schema.params) do
                 table.insert(param_schema_values, string.format(
-                    "ParamSchema{%q, %s, %d, %d, %s }",
+                    "ParamSchema{%q, %s, %d, %d, %s, %q, %s }",
                     param_schema.name,
                     doc_to_str(param_schema.doc),
                     param_schema.index,
                     pt_index_by_name[param_schema.type],
-                    tostring(param_schema.required)
+                    tostring(param_schema.required),
+                    primitive_to_str(param_schema.default_value, param_schema.type),
+                    doc_to_str(param_schema.default_value_doc)
                 ))
             end
         end
@@ -109,6 +127,9 @@
     end
 }}
 #include "system/schema.h"
+
+#include "parser/Parser.h"
+#include "parser/TokenView.h"
 
 namespace sq::system {
 namespace {
@@ -168,6 +189,20 @@ bool ParamSchema::required() const
   return required_;
 }
 
+std::optional<Primitive> ParamSchema::default_value() const
+{
+  if (default_value_str_.empty()) {
+    return std::nullopt;
+  }
+  auto tokens = parser::TokenView{default_value_str_};
+  return parser::Parser{tokens}.parse_primitive();
+}
+
+std::string_view ParamSchema::default_value_doc() const
+{
+  return default_value_doc_;
+}
+
 std::string_view FieldSchema::name() const
 {
     return name_;
@@ -194,6 +229,11 @@ const TypeSchema& FieldSchema::return_type() const
 bool FieldSchema::return_list() const
 {
     return return_list_;
+}
+
+bool FieldSchema::null() const
+{
+  return null_;
 }
 
 std::string_view TypeSchema::name() const

--- a/test/test_sq_path.py
+++ b/test/test_sq_path.py
@@ -188,13 +188,25 @@ def test_canonical(tmp_path, path_info):
     assert result == str(canonical_path)
 
 
-def test_size(tmp_path):
+def test_size_of_file(tmp_path):
     path = tmp_path / "file"
     quoted_path = util.quote(str(path))
     path.write_text("Some data")
     size = path.stat().st_size
     result = util.sq(f"<path({quoted_path}).<size")
     assert result == size
+
+def test_size_of_directory(tmp_path):
+    path = tmp_path / "dir"
+    quoted_path = util.quote(str(path))
+    path.mkdir()
+    result = util.sq(f"<path({quoted_path}).<size")
+    assert result == None
+
+def test_size_of_non_existent(tmp_path):
+    path = tmp_path / "nonexistent"
+    quoted_path = util.quote(str(path))
+    result = util.sq_error(f"<path({quoted_path}).<size", "file ?not ?found")
 
 
 def test_children(tmp_path):

--- a/test/test_sq_schema.py
+++ b/test/test_sq_schema.py
@@ -20,8 +20,7 @@ def test_schema(sq_schema):
     # There are a couple of things that will be different between the two
     # schemas though:
     # * doc arrays will have been converted to single strings with newlines.
-    # * SqParamSchema::default_value and SqParamSchema::default_value_doc are
-    #   not currently available when querying SQ.
+    # * optional fields will always exist but might be null.
     #
     # Modify the schema we got from schema.json to match what we think SQ
     # should return, then just do a test using "=="
@@ -32,20 +31,23 @@ def test_schema(sq_schema):
             flatten_doc_list(f)
             for p in f["params"]:
                 flatten_doc_list(p)
-                p.pop("default_value", None)
-                p.pop("default_value_doc", None)
+                if "default_value" not in p:
+                    p["default_value"] = None
+                if "default_value_doc" not in p:
+                    p["default_value_doc"] = None
 
     result = util.sq(
         "schema {"
-        "types {"
-        "name doc fields { "
-        "name doc return_type return_list params {"
-        "name doc index type required"
-        "}"
-        "}"
-        "}"
-        " primitive_types { name doc }"
-        " root_type"
+            "types {"
+                "name doc fields { "
+                    "name doc return_type return_list null params {"
+                        "name doc index type required "
+                        "default_value default_value_doc"
+                    "}"
+                "}"
+            "}"
+            " primitive_types { name doc }"
+            " root_type"
         "}"
     )
     assert result == {"schema": schema}


### PR DESCRIPTION
Fixes #75: Add support for "null" results
Fixes #79: Handle `path.size` better when path is a directory

Add support for fields to return null. With that support we can clean up
a few things:

* Add SqParamSchema::default_value and SqParamSchema::default_value_doc
  which were previously missing because there wasn't a mechanism for
  them to be null.

* Get SqPath::size to return null when the path is not a regular file or
  a symlink. Also generally improve error handling in this function.

* Get SqDevice::dev_node and SqDevice::subsystem to return null when
  there is no value to return rather than returning the empty string.