### PR TITLE
Add SqPath field to get hard link count

### DIFF
--- a/src/common_types/include/common_types/errors.h
+++ b/src/common_types/include/common_types/errors.h
@@ -14,6 +14,7 @@
 #include <gsl/gsl>
 #include <stdexcept>
 #include <string_view>
+#include <system_error>
 
 namespace sq {
 
@@ -169,17 +170,15 @@ class UdevError : public Exception {
  * Error indicating that a filesystem error ocurred.
  */
 class FilesystemError : public Exception {
-  using Exception::Exception;
-};
-
-/**
- * Error indicating that a file does not exist.
- */
-class FileNotFoundError : public FilesystemError {
 public:
-  using FilesystemError::FilesystemError;
+  using Exception::Exception;
+  FilesystemError(std::string_view operation, const std::filesystem::path &path,
+                  std::error_code code);
 
-  FileNotFoundError(const std::filesystem::path &path);
+  std::error_code code() const;
+
+private:
+  std::error_code code_;
 };
 
 } // namespace sq

--- a/src/common_types/src/errors.cpp
+++ b/src/common_types/src/errors.cpp
@@ -68,7 +68,13 @@ ParseError::ParseError(const Token &token, const TokenKindSet &expecting)
           "parse error: unexpected {}; expecting one of: {}\n{}", token,
           fmt::join(expecting, ", "), show_pos_in_query(token))} {}
 
-FileNotFoundError::FileNotFoundError(const std::filesystem::path &path)
-    : FilesystemError{fmt::format("file {} not found", path)} {}
+FilesystemError::FilesystemError(std::string_view operation,
+                                 const std::filesystem::path &path,
+                                 std::error_code code)
+    : Exception{fmt::format("{} failed for path {}: {}", operation, path,
+                            code.message())},
+      code_{code} {}
+
+std::error_code FilesystemError::code() const { return code_; }
 
 } // namespace sq

--- a/src/system/include/system/linux/SqPathImpl.h
+++ b/src/system/include/system/linux/SqPathImpl.h
@@ -10,6 +10,7 @@
 #include "util/typeutil.h"
 
 #include <filesystem>
+#include <sys/stat.h>
 
 namespace sq::system::linux {
 
@@ -31,10 +32,14 @@ public:
   SQ_ND Result get_size(PrimitiveBool follow_symlinks) const;
   SQ_ND Result get_exists(PrimitiveBool follow_symlinks) const;
   SQ_ND Result get_type(PrimitiveBool follow_symlinks) const;
+  SQ_ND Result get_hard_link_count(PrimitiveBool follow_symlinks) const;
   SQ_ND Primitive to_primitive() const override;
 
 private:
+  const struct stat &get_stat(bool follow_symlinks) const;
   std::filesystem::path value_;
+  mutable std::optional<struct stat> stat_;
+  mutable std::optional<struct stat> lstat_;
 };
 
 } // namespace sq::system::linux

--- a/src/system/schema.json
+++ b/src/system/schema.json
@@ -514,6 +514,23 @@
                             "default_value": true
                         }
                     ]
+                },
+                {
+                    "name": "hard_link_count",
+                    "doc": "Get the number of hard links for the file referred to by the path",
+                    "return_type": "SqInt",
+                    "return_list": false,
+                    "null": false,
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "follow_symlinks",
+                            "doc": "Whether to dereference symlinks",
+                            "type": "PrimitiveBool",
+                            "required": false,
+                            "default_value": true
+                        }
+                    ]
                 }
             ]
         },

--- a/src/util/include/util/typeutil.h
+++ b/src/util/include/util/typeutil.h
@@ -11,6 +11,7 @@
 #include <gsl/gsl>
 #include <range/v3/range/concepts.hpp>
 #include <string>
+#include <system_error>
 #include <type_traits>
 #include <variant>
 
@@ -121,6 +122,13 @@ SQ_ND inline constexpr std::size_t to_size(std::integral auto v) {
  * The "base type" is the type with no references or cv qualification.
  */
 SQ_ND std::string base_type_name(const auto &thing);
+
+/**
+ * Create a std::error code from a platform dependent error code.
+ */
+SQ_ND inline std::error_code make_error_code(int code) {
+  return std::make_error_code(static_cast<std::errc>(code));
+}
 
 } // namespace sq::util
 


### PR DESCRIPTION
Also, switch to using POSIX stat(2) and lstat(2) rather than
std::filesystem because the limitations of std::filesystem mean multiple
std::filesystem calls are required to get information that can obtained
with a single call to stat(2) or lstat(2).