### PR TITLE
Add option to SqPath::children to recurse into subdirectories

### DIFF
--- a/src/system/include/system/linux/SqPathImpl.h
+++ b/src/system/include/system/linux/SqPathImpl.h
@@ -23,7 +23,9 @@ public:
   SQ_ND Result get_filename() const;
   SQ_ND Result get_extension() const;
   SQ_ND Result get_stem() const;
-  SQ_ND Result get_children() const;
+  SQ_ND Result get_children(PrimitiveBool recurse,
+                            PrimitiveBool follow_symlinks,
+                            PrimitiveBool skip_permission_denied) const;
   SQ_ND Result get_parts() const;
   SQ_ND Result get_absolute() const;
   SQ_ND Result get_canonical() const;

--- a/src/system/schema.json
+++ b/src/system/schema.json
@@ -558,7 +558,32 @@
                     "return_type": "SqPath",
                     "return_list": true,
                     "null": false,
-                    "params": []
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "recurse",
+                            "doc": "Whether recursively list children of subdirectories",
+                            "type": "PrimitiveBool",
+                            "required": false,
+                            "default_value": false
+                        },
+                        {
+                            "index": 1,
+                            "name": "follow_symlinks",
+                            "doc": "Whether to dereference symlinks",
+                            "type": "PrimitiveBool",
+                            "required": false,
+                            "default_value": false
+                        },
+                        {
+                            "index": 1,
+                            "name": "skip_permission_denied",
+                            "doc": "Whether to skip subdirectories that would otherwise cause permission errors",
+                            "type": "PrimitiveBool",
+                            "required": false,
+                            "default_value": false
+                        }
+                    ]
                 },
                 {
                     "name": "parts",

--- a/test/util/__init__.py
+++ b/test/util/__init__.py
@@ -115,3 +115,7 @@ def sq_error(query, pattern=None, flags=re.I):
 
 def quote(string):
     return '"{}"'.format(string.replace("\\", "\\\\").replace('"', '\\"'))
+
+
+def bool_str(b):
+    return "true" if b else "false"


### PR DESCRIPTION
For #104: Add option to SqPath::children to recurse into subdirectories